### PR TITLE
Integrate Weights & Biases for training run tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
 ANTHROPIC_API_KEY=anthropic_api_key
+WANDB_API_KEY=your_wandb_api_key
+WANDB_ENTITY=chm-ml
+WANDB_PROJECT=algorithmic-institutions

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ Install `djx` sub-module in editable mode:
 uv pip install -e djx
 ```
 
+### 4. Secrets (`.env`)
+
+Copy `.env.example` to `.env` and fill in the API keys:
+
+```bash
+cp .env.example .env
+```
+
+To log training runs to Weights & Biases, set `WANDB_API_KEY`. On Raven, copy the
+key from an existing project (e.g. the `collectively-grounded-llms` repo) or grab
+it from https://wandb.ai/authorize. `.env` is gitignored; SLURM templates source
+it to export `WANDB_*` variables into the job environment.
+
 ### Alternative: Manual virtual environment setup
 If you prefer to set up the virtual environment manually without `uv`, you can follow these steps:
 

--- a/configs/training/artificial_humans/smoketest_wandb.yml
+++ b/configs/training/artificial_humans/smoketest_wandb.yml
@@ -1,0 +1,58 @@
+description: >-
+  Small smoketest to verify wandb integration.
+exec:
+  command: python -m aimanager train-ah {job_file}
+  script_name: run_training
+  data_dir: artifacts
+  temp_dir: .log
+  cores: 4
+  memory: 8
+params_only: true
+params:
+  fraction_training: 1.0
+  seed: 38381
+  mask_name: contribution_valid
+  experiment_names: [ah_group_switching]
+  labels:
+    architecture: node+edge+rnn
+    dataset: smoketest
+  n_contributions: 21
+  n_punishments: 31
+  n_cross_val: 2
+  n_player: 8
+  n_groups: 2
+  data_file: experiments/group_switching_human_human_group_switching_8_agents.csv
+  model_name: graph
+  shuffle_features: [prev_punishment, prev_contribution, contribution_valid]
+  basedir: .
+  output_dir: artifacts/artificial_humans/smoketest_wandb
+  model_args:
+    y_levels: 21
+    y_name: contribution
+    hidden_size: 20
+    add_rnn: True
+    add_edge_model: True
+    add_global_model: False
+    x_encoding:
+      - name: prev_contribution
+        n_levels: 21
+        encoding: numeric
+      - name: prev_punishment
+        n_levels: 31
+        encoding: numeric
+      - name: agent_group
+        n_levels: 2
+        encoding: numeric
+      - etype: bool
+        name: prev_contribution_valid
+  optimizer_args:
+    lr: 1.e-4
+    weight_decay: 1.e-5
+  train_args:
+    epochs: 200
+    batch_size: 4
+    clamp_grad: 1
+    eval_period: 20
+    l1_entropy: 0
+  device: cuda
+  autoregression: False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "torch-geometric==2.5.0 ; sys_platform == 'linux'",
     "fastparquet>=2024.11.0",
     "toolz>=1.1.0",
+    "wandb>=0.17",
 ]
 
 [dependency-groups]

--- a/scripts/artificial_humans/run_training.sh
+++ b/scripts/artificial_humans/run_training.sh
@@ -22,5 +22,13 @@ source .venv/bin/activate
 
 module load cuda/11.4
 
+if [ -f .env ]; then
+    set -a
+    source .env
+    set +a
+fi
+export WANDB_RUN_GROUP={experiment_name}
+export WANDB_NAME={job_id}
+
 # python src/aimanager/artificial_humans/train.py $CONFIG_PATH
 {command}

--- a/scripts/manager/run_training.sh
+++ b/scripts/manager/run_training.sh
@@ -22,4 +22,12 @@ source .venv/bin/activate
 
 module load cuda/11.4
 
+if [ -f .env ]; then
+    set -a
+    source .env
+    set +a
+fi
+export WANDB_RUN_GROUP={experiment_name}
+export WANDB_NAME={job_id}
+
 python -m aimanager train-manager {config_path}

--- a/scripts/remote_test.sh
+++ b/scripts/remote_test.sh
@@ -72,6 +72,7 @@ check_ssh() {
 sync_files() {
     info "Syncing files to ${REMOTE_HOST}:${REMOTE_PROJECT_DIR}..."
     rsync -azP --delete \
+        --filter='P /.env' \
         --filter=':- .gitignore' \
         --exclude='.git/' \
         --exclude='.venv/' \

--- a/scripts/simulate_cluster.sh
+++ b/scripts/simulate_cluster.sh
@@ -61,6 +61,7 @@ check_ssh() {
 sync_files() {
     info "Syncing files to ${REMOTE_HOST}:${REMOTE_PROJECT_DIR}..."
     rsync -azP --delete \
+        --filter='P /.env' \
         --filter=':- .gitignore' \
         --exclude='.git/' \
         --exclude='.venv/' \

--- a/scripts/train_cluster.sh
+++ b/scripts/train_cluster.sh
@@ -67,6 +67,7 @@ check_ssh() {
 sync_files() {
     info "Syncing files to ${REMOTE_HOST}:${REMOTE_PROJECT_DIR}..."
     rsync -azP --delete \
+        --filter='P /.env' \
         --filter=':- .gitignore' \
         --exclude='.git/' \
         --exclude='.venv/' \

--- a/src/aimanager/artificial_humans/run.py
+++ b/src/aimanager/artificial_humans/run.py
@@ -57,6 +57,8 @@ def queue_job(job):
     output_path = f"{run_dir}"
     job_only = job["exec"].get("job_only", False)
 
+    experiment_name = os.path.splitext(job.get("exp_name", ""))[0] or job_id
+
     script_str = create_script(
         **job["exec"],
         job_id=job_id,
@@ -64,6 +66,7 @@ def queue_job(job):
         log_file=log_file,
         output_path=output_path,
         run_dir=run_dir,
+        experiment_name=experiment_name,
     )
 
     if job.get("params_only"):

--- a/src/aimanager/artificial_humans/train.py
+++ b/src/aimanager/artificial_humans/train.py
@@ -5,6 +5,7 @@ import pandas as pd
 import numpy as np
 import random
 import torch as th
+import wandb
 from aimanager.generic.data import create_torch_data, get_cross_validations
 from aimanager.artificial_humans import AH_MODELS
 from aimanager.artificial_humans.evaluation import (
@@ -146,6 +147,10 @@ def main(config):
 
     rec = Recorder()
 
+    wandb_enabled = bool(os.environ.get("WANDB_API_KEY"))
+    if wandb_enabled:
+        wandb.init(config=config)
+
     th_device = th.device(device)
 
     if autoregression:
@@ -272,6 +277,7 @@ def main(config):
                     rec.rec_many(metrics, set="train", n_pred=n_pred, mask=j)
 
                 test_log_loss = None
+                perturb_log_loss = {}
                 if test_data is not None:
                     # evalute on test data for all possible mask patterns
                     for j, mask in enumerate(test_mask_pattern):
@@ -322,6 +328,24 @@ def main(config):
                                     n_pred=n_pred,
                                     mask=j,
                                 )
+                                if j == 0:
+                                    for m in metrics:
+                                        if m["name"] == "log_loss":
+                                            perturb_log_loss[
+                                                f"{lbl}_{feat}"
+                                            ] = m["value"]
+
+                if wandb_enabled:
+                    wandb_log = {
+                        "epoch": e,
+                        "fold": i,
+                        f"fold_{i}/train/loss": avg_loss,
+                    }
+                    if test_log_loss is not None:
+                        wandb_log[f"fold_{i}/test/log_loss"] = test_log_loss
+                        for key, val in perturb_log_loss.items():
+                            wandb_log[f"fold_{i}/test/log_loss__{key}"] = val
+                    wandb.log(wandb_log)
 
                 postfix = {"loss": f"{avg_loss:.4f}"}
                 if test_log_loss is not None:
@@ -392,6 +416,9 @@ def main(config):
             conf_m = pd.concat(conf_m_all)
             conf_m.to_parquet(conf_path)
         rec.save(output_dir, labels, job_id=job_id)
+
+    if wandb_enabled:
+        wandb.finish()
 
 
 if __name__ == "__main__":

--- a/src/aimanager/manager/run.py
+++ b/src/aimanager/manager/run.py
@@ -71,6 +71,7 @@ def run(config_path):
         log_file=log_file,
         job_id=job_id,
         config_path=config_path,
+        experiment_name=config_name,
     )
     write_file(script_str, script_file)
 

--- a/src/aimanager/rl_manager.py
+++ b/src/aimanager/rl_manager.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 import numpy as np
 import pandas as pd
 import torch as th
+import wandb
 
 from aimanager.manager.memory import Memory
 from aimanager.manager.environment import ArtificialHumanEnv
@@ -98,6 +99,10 @@ def train_manager(config: dict, labels=None, data_dir: str = None):
     th.random.manual_seed(seed)
     np.random.seed(seed)
     random.seed(seed)
+
+    wandb_enabled = bool(os.environ.get("WANDB_API_KEY"))
+    if wandb_enabled:
+        wandb.init(config=config)
 
     # Output directories
     output_dir = data_dir or config["output_dir"]
@@ -210,15 +215,32 @@ def train_manager(config: dict, labels=None, data_dir: str = None):
                 metrics_list.extend(
                     [{**m, "loss": loss.item()} for m in off_policy_metrics]
                 )
-            metrics_list.extend(
-                run_batch(
-                    manager,
-                    env,
-                    replay_mem=None,
-                    on_policy=True,
-                    update_step=update_step,
-                )
+            on_policy_metrics = run_batch(
+                manager,
+                env,
+                replay_mem=None,
+                on_policy=True,
+                update_step=update_step,
             )
+            metrics_list.extend(on_policy_metrics)
+
+            if wandb_enabled:
+                log = {"update_step": update_step}
+                if sample is not None:
+                    log["train/loss"] = loss.item()
+                for k in [
+                    "next_reward",
+                    "common_good",
+                    "contribution",
+                    "punishment",
+                    "group_payoff",
+                    "q_mean",
+                ]:
+                    log[f"eval/{k}"] = (
+                        sum(m[k] for m in on_policy_metrics)
+                        / len(on_policy_metrics)
+                    )
+                wandb.log(log)
 
     model_file = os.path.join(model_dir, f"{config['job_id']}_manager.pt")
     print(f"Saving manager to {model_file}")
@@ -250,6 +272,9 @@ def train_manager(config: dict, labels=None, data_dir: str = None):
     df = df.melt(id_vars=id_vars, value_vars=value_vars, var_name="metric")
     df = add_labels(df, {**labels, "job_id": config["job_id"]})
     df.to_parquet(metrics_path)
+
+    if wandb_enabled:
+        wandb.finish()
 
     return model_file
 


### PR DESCRIPTION
## Summary
- Plumb `WANDB_*` env vars through SLURM templates for AH and manager training (sources `.env`, exports `WANDB_RUN_GROUP={experiment_name}` / `WANDB_NAME={job_id}`).
- Wire `wandb.init`/`log`/`finish` into `src/aimanager/artificial_humans/train.py`: per-fold `train/loss`, test `log_loss` (j=0), and shuffle/ablate perturbation `log_loss`.
- Wire `wandb.init`/`log`/`finish` into `src/aimanager/rl_manager.py`: per eval-period `train/loss` and `eval/{next_reward, common_good, contribution, punishment, group_payoff, q_mean}`.
- Add `wandb` dependency; add `WANDB_*` lines to `.env.example`; document `.env` setup in README.
- Fix rsync sync scripts so `.env` on Raven survives `--delete` (added `--filter='P /.env'`).
- Add `configs/training/artificial_humans/smoketest_wandb.yml` (tiny config used to verify the integration).

Closes #79.

## Out of scope (per issue)
- Migrating offline plotting scripts to consume the wandb API.
- Logging the simulation pipeline to wandb.

## Test plan
- [x] AH smoketest — submitted and verified on wandb
- [x] RL manager smoketest — submitted and verified on wandb
- [ ] Full grid search submission to confirm sweeps view renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)