### PR TITLE
Add reward_mode flag: sum vs avg group payoff (#68)

### DIFF
--- a/configs/training/rl_manager/01_rnn_node.yml
+++ b/configs/training/rl_manager/01_rnn_node.yml
@@ -46,6 +46,7 @@ env_args:
   n_punishments: 31
   n_rounds: 24
   batch_size: 1000
+  reward_mode: avg
 
 device: "cuda"
 output_dir: "artifacts/manager/01_rnn_node_v3"

--- a/configs/training/rl_manager/01_rnn_node_group_payoff_round.yml
+++ b/configs/training/rl_manager/01_rnn_node_group_payoff_round.yml
@@ -44,6 +44,7 @@ env_args:
   n_punishments: 31
   n_rounds: 24
   batch_size: 1000
+  reward_mode: avg
 
 device: "cuda"
 output_dir: "artifacts/manager/01_rnn_node_group_payoff_round"

--- a/configs/training/rl_manager/02_rnn_node_1group.yml
+++ b/configs/training/rl_manager/02_rnn_node_1group.yml
@@ -46,6 +46,7 @@ env_args:
   n_punishments: 31
   n_rounds: 24
   batch_size: 1000
+  reward_mode: avg
 
 device: "cuda"
 output_dir: "artifacts/manager/02_rnn_node_1group"

--- a/configs/training/rl_manager/02_rnn_node_2groups.yml
+++ b/configs/training/rl_manager/02_rnn_node_2groups.yml
@@ -47,6 +47,7 @@ env_args:
   n_punishments: 31
   n_rounds: 24
   batch_size: 1000
+  reward_mode: avg
 
 device: "cuda"
 output_dir: "artifacts/manager/02_rnn_node_2groups"

--- a/configs/training/rl_manager/test_01_rnn_node.yml
+++ b/configs/training/rl_manager/test_01_rnn_node.yml
@@ -44,6 +44,7 @@ env_args:
   n_punishments: 31
   n_rounds: 24
   batch_size: 100
+  reward_mode: avg
 
 device: "cuda"
 output_dir: "artifacts/manager/test_01_rnn_node"

--- a/doc/plans/reward_mode_sum.md
+++ b/doc/plans/reward_mode_sum.md
@@ -91,7 +91,7 @@ separate follow-up, not part of this plan.
 - [x] Step 2: payoff fn returns sum and avg in one pass
 - [x] Step 3: add `group_payoff_sum` to state dict
 - [x] Step 4: `update_payoff` writes both; `update_reward` selects via `reward_mode`
-- [ ] Step 5: wire `reward_mode` through `manager.py` and `simulate.py`
+- [x] Step 5: wire `reward_mode` through `simulate.py` (rl_manager already spreads `**env_args`); add `reward_mode: avg` to all 5 legacy RL manager YAMLs
 - [ ] Step 6: unit test in `src/aimanager/tests/test_environment.py`
 - [ ] Run `scripts/remote_test.sh` on Raven
 - [ ] Lint pass (`pre-commit run --all-files`) and commit via `/commit`

--- a/doc/plans/reward_mode_sum.md
+++ b/doc/plans/reward_mode_sum.md
@@ -1,0 +1,94 @@
+# [DRAFT] Reward mode: sum vs avg for group-switching RL manager
+
+## Goal
+
+The group-switching RL manager currently optimises the **average** payoff per
+group member, which makes the manager indifferent to group size. With
+group-switching enabled, group size is endogenous — managers that retain or
+attract members should be rewarded for it. Switch the reward to the **sum** of
+in-group payoffs so the manager is incentivised on both per-member payoff and
+group size. Keep `avg` available as a config-selectable mode so the two reward
+schemes can be compared empirically. Default is `sum` — this is the new
+intended behaviour; legacy configs must explicitly set `reward_mode: avg` to
+reproduce their original reward signal.
+
+## Changes
+
+| # | Section | Change | Optional |
+|---|---------|--------|----------|
+| 1 | Env constructor | New `reward_mode` kwarg | no |
+| 2 | Payoff computation | Compute sum alongside avg | no |
+| 3 | State dict | Add `group_payoff_sum` field | no |
+| 4 | Reward selection | Pick sum vs avg per `reward_mode` | no |
+| 5 | Manager wiring | Pipe `reward_mode` through config | no |
+| 6 | Unit test | Cover both modes on a tiny batch | no |
+
+### 1. Env constructor — `src/aimanager/manager/environment.py:43,75-105`
+- Add `reward_mode: str = "sum"` kwarg to the env `__init__`; store as
+  `self.reward_mode`.
+- Validate it's one of `{"avg", "sum"}`; raise `ValueError` otherwise.
+
+### 2. Payoff computation — `src/aimanager/manager/environment.py:216-243`
+- In `compute_average_payoff_per_group`, the existing numerator
+  (`payoff * agent_group_mask * contribution_valid` summed over agents) is the
+  per-group **sum** we want. Return both:
+  ```
+  group_payoff_sum = numerator                              # (B, G, 1)
+  group_payoff_avg = numerator / contribution_valid.sum(...) # existing value
+  ```
+- Rename internally or add a sibling method — whichever keeps the diff small.
+  The avg path must remain numerically unchanged.
+
+### 3. State dict — `src/aimanager/manager/environment.py:131-156`
+- In `reset_state`, add `group_payoff_sum` with the same shape as the existing
+  `group_payoff` field: `(batch_size, n_groups, 1)`, zero-initialised.
+- Keep the existing `group_payoff` key for `avg` (don't rename, to avoid
+  breaking downstream loggers/notebooks).
+
+### 4. Reward selection — `src/aimanager/manager/environment.py:270-282`
+- In `update_payoff`: write both `group_payoff` (avg) and `group_payoff_sum`
+  into state every round, regardless of `reward_mode`. This keeps diagnostics
+  comparable across runs.
+- In `update_reward`: select the field to use as the optimisation signal based
+  on `self.reward_mode` (`group_payoff` for `"avg"`, `group_payoff_sum` for
+  `"sum"`).
+
+### 5. Manager wiring — `src/aimanager/manager/manager.py` and `src/aimanager/simulation/simulate.py:184`
+- Wherever the env is built from config (constructor / factory in this file,
+  and the `ArtificialHumanEnv(...)` call in `simulate.py`), read `reward_mode`
+  from the config dict and forward it to the env. Default to `"sum"` if the
+  key is absent — matches the env-constructor default.
+
+## Test
+
+Add one test in `src/aimanager/tests/test_environment.py` that constructs the
+env twice on a tiny hand-built batch (two groups, asymmetric sizes, known
+contributions and payoffs): once with `reward_mode="avg"` and once with
+`reward_mode="sum"`. Assert (a) `state["group_payoff"]` matches the existing
+average formula in both runs, (b) `state["group_payoff_sum"]` equals the
+numerator (sum over valid in-group payoffs) in both runs, and (c) the reward
+returned by `update_reward` equals avg in the first run and sum in the second.
+Run on Raven via `scripts/remote_test.sh` — the suite cannot run locally
+(PyG/torch-scatter is Linux-only).
+
+## Config migration note
+
+Default is `sum`, so legacy RL manager configs (e.g.
+`configs/training/rl_manager/02_rnn_node_2groups.yml`,
+`configs/training/rl_manager/02_rnn_node_1group.yml`) will switch reward
+signal unless they explicitly set `reward_mode: avg`. If we want to keep the
+existing comparison runs reproducible, add `reward_mode: avg` to those YAMLs
+as part of this PR. New configs can omit the key.
+
+## Out of scope
+
+A new 2g8a RL manager config (using the 50ep AHs) with `reward_mode: sum` is a
+separate follow-up, not part of this plan.
+
+## Next Actions
+
+- [ ] Implement env changes (1-4) in `src/aimanager/manager/environment.py`
+- [ ] Wire `reward_mode` through in `src/aimanager/manager/manager.py`
+- [ ] Add unit test in `src/aimanager/tests/test_environment.py`
+- [ ] Run `scripts/remote_test.sh` on Raven
+- [ ] Lint pass (`pre-commit run --all-files`) and commit via `/commit`

--- a/doc/plans/reward_mode_sum.md
+++ b/doc/plans/reward_mode_sum.md
@@ -89,8 +89,8 @@ separate follow-up, not part of this plan.
 
 - [x] Step 1: env constructor `reward_mode` kwarg + validation
 - [x] Step 2: payoff fn returns sum and avg in one pass
-- [ ] Step 3: add `group_payoff_sum` to state dict
-- [ ] Step 4: `update_payoff` writes both; `update_reward` selects via `reward_mode`
+- [x] Step 3: add `group_payoff_sum` to state dict
+- [x] Step 4: `update_payoff` writes both; `update_reward` selects via `reward_mode`
 - [ ] Step 5: wire `reward_mode` through `manager.py` and `simulate.py`
 - [ ] Step 6: unit test in `src/aimanager/tests/test_environment.py`
 - [ ] Run `scripts/remote_test.sh` on Raven

--- a/doc/plans/reward_mode_sum.md
+++ b/doc/plans/reward_mode_sum.md
@@ -92,6 +92,6 @@ separate follow-up, not part of this plan.
 - [x] Step 3: add `group_payoff_sum` to state dict
 - [x] Step 4: `update_payoff` writes both; `update_reward` selects via `reward_mode`
 - [x] Step 5: wire `reward_mode` through `simulate.py` (rl_manager already spreads `**env_args`); add `reward_mode: avg` to all 5 legacy RL manager YAMLs
-- [ ] Step 6: unit test in `src/aimanager/tests/test_environment.py`
-- [ ] Run `scripts/remote_test.sh` on Raven
+- [x] Step 6: unit test in `src/aimanager/tests/test_environment.py`
+- [x] Run `scripts/remote_test.sh` on Raven (6/6 passed)
 - [ ] Lint pass (`pre-commit run --all-files`) and commit via `/commit`

--- a/doc/plans/reward_mode_sum.md
+++ b/doc/plans/reward_mode_sum.md
@@ -1,4 +1,4 @@
-# [DRAFT] Reward mode: sum vs avg for group-switching RL manager
+# [ACTIVE] Reward mode: sum vs avg for group-switching RL manager
 
 ## Goal
 
@@ -87,8 +87,11 @@ separate follow-up, not part of this plan.
 
 ## Next Actions
 
-- [ ] Implement env changes (1-4) in `src/aimanager/manager/environment.py`
-- [ ] Wire `reward_mode` through in `src/aimanager/manager/manager.py`
-- [ ] Add unit test in `src/aimanager/tests/test_environment.py`
+- [x] Step 1: env constructor `reward_mode` kwarg + validation
+- [x] Step 2: payoff fn returns sum and avg in one pass
+- [ ] Step 3: add `group_payoff_sum` to state dict
+- [ ] Step 4: `update_payoff` writes both; `update_reward` selects via `reward_mode`
+- [ ] Step 5: wire `reward_mode` through `manager.py` and `simulate.py`
+- [ ] Step 6: unit test in `src/aimanager/tests/test_environment.py`
 - [ ] Run `scripts/remote_test.sh` on Raven
 - [ ] Lint pass (`pre-commit run --all-files`) and commit via `/commit`

--- a/scripts/tests/diagnose_reward_mode.py
+++ b/scripts/tests/diagnose_reward_mode.py
@@ -1,0 +1,107 @@
+"""Side-by-side dump of env reward fields under reward_mode=avg vs sum.
+
+Builds the same 6-agent / 2-group / asymmetric env used in the unit tests,
+runs `punish` then `step`, and prints expected vs actual values so a reviewer
+can eyeball that:
+  * `group_payoff` (avg) and `group_payoff_sum` are logged in BOTH modes,
+  * `reward` selects `group_payoff` under `avg` and `group_payoff_sum`
+    under `sum`.
+
+Run on Raven via scripts/remote_test.sh (PyG/torch-scatter is Linux-only).
+"""
+
+import torch as th
+
+from aimanager.manager.environment import ArtificialHumanEnv
+
+
+class MockAH:
+    def __init__(self, default_values):
+        self.default_values = default_values
+
+    def predict(self, state, reset_rnn, edge_index):
+        return (th.ones(state["contribution"].shape, dtype=th.long),)
+
+
+class MockAHValid:
+    def predict(self, state, reset_rnn, edge_index):
+        return (th.ones(state["contribution"].shape, dtype=th.bool),)
+
+
+def build_env(reward_mode):
+    defaults = {
+        "punishment": 1,
+        "contribution": 1,
+        "payoffs": 1,
+        "contribution_valid": True,
+        "common_good": 1,
+        "round_number": 1,
+        "player_id": 1,
+    }
+    return ArtificialHumanEnv(
+        artifical_humans=MockAH(defaults),
+        artifical_humans_valid=MockAHValid(),
+        batch_size=1,
+        n_agents=6,
+        n_contributions=3,
+        n_punishments=3,
+        n_rounds=2,
+        n_groups=2,
+        device="cpu",
+        agent_groups=[0, 0, 0, 0, 1, 1],
+        reward_mode=reward_mode,
+        default_values={
+            "punishment": 0,
+            "contribution": 0,
+            "round_number": 0,
+            "is_first": False,
+            "contribution_valid": False,
+            "punishment_valid": False,
+            "common_good": 0,
+            "contributor_payoff": 0,
+            "manager_payoff": 0,
+            "reward": 0,
+        },
+    )
+
+
+def main():
+    punishment = th.tensor([[[1], [0], [2], [1], [0], [2]]])
+
+    # Hand-computed expected values:
+    # group 0 (4 agents, punish=[1,0,2,1]): cg = (4*1.6-4)/4 = 0.6
+    #   payoffs [18.6, 19.6, 17.6, 18.6] -> sum 74.4, avg 18.6
+    # group 1 (2 agents, punish=[0,2]):    cg = (2*1.6-2)/2 = 0.6
+    #   payoffs [19.6, 17.6]              -> sum 37.2, avg 18.6
+    expected_avg = th.tensor([[[18.6], [18.6]]])
+    expected_sum = th.tensor([[[74.4], [37.2]]])
+
+    print("=== reward_mode comparison (group sizes: 4, 2) ===")
+    print(f"punishment        : {punishment.flatten().tolist()}")
+    print(f"expected avg/grp  : {expected_avg.flatten().tolist()}")
+    print(f"expected sum/grp  : {expected_sum.flatten().tolist()}")
+
+    for mode in ("avg", "sum"):
+        env = build_env(mode)
+        env.punish(punishment)
+
+        gp = env.group_payoff.flatten().tolist()
+        gps = env.group_payoff_sum.flatten().tolist()
+        _, reward, _ = env.step()
+        r = reward.flatten().tolist()
+
+        print(f"\n--- reward_mode={mode!r} ---")
+        print(f"  state['group_payoff']     (avg) = {gp}")
+        print(f"  state['group_payoff_sum']       = {gps}")
+        print(f"  reward returned by step()       = {r}")
+
+        ok_avg = th.allclose(env.group_payoff, expected_avg)
+        ok_sum = th.allclose(env.group_payoff_sum, expected_sum)
+        ok_rwd = th.allclose(reward, expected_sum if mode == "sum" else expected_avg)
+        print(f"  avg field correct : {ok_avg}")
+        print(f"  sum field correct : {ok_sum}")
+        print(f"  reward selects {mode} : {ok_rwd}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aimanager/manager/environment.py
+++ b/src/aimanager/manager/environment.py
@@ -80,9 +80,7 @@ class ArtificialHumanEnv:
         self.switch_every = switch_every
         self.n_agents = n_agents
         if reward_mode not in ("avg", "sum"):
-            raise ValueError(
-                f"reward_mode must be 'avg' or 'sum', got {reward_mode!r}"
-            )
+            raise ValueError(f"reward_mode must be 'avg' or 'sum', got {reward_mode!r}")
         self.reward_mode = reward_mode
         self.batch = th.tensor(
             [i for i in range(self.batch_size) for a in range(self.n_agents)],

--- a/src/aimanager/manager/environment.py
+++ b/src/aimanager/manager/environment.py
@@ -42,6 +42,7 @@ class ArtificialHumanEnv:
         n_groups=1,
         agent_groups=None,
         default_values=None,
+        reward_mode="sum",
     ):
         """
         Args:
@@ -78,6 +79,11 @@ class ArtificialHumanEnv:
         self.artifical_humans_switch = artifical_humans_switch
         self.switch_every = switch_every
         self.n_agents = n_agents
+        if reward_mode not in ("avg", "sum"):
+            raise ValueError(
+                f"reward_mode must be 'avg' or 'sum', got {reward_mode!r}"
+            )
+        self.reward_mode = reward_mode
         self.batch = th.tensor(
             [i for i in range(self.batch_size) for a in range(self.n_agents)],
             device=self.device,
@@ -213,7 +219,7 @@ class ArtificialHumanEnv:
         )
         return common_good_per_group
 
-    def compute_average_payoff_per_group(
+    def compute_payoff_per_group(
         self, contribution, punishment, contribution_valid, common_good
     ):
         # Used both with punishment and prev_punishment
@@ -226,21 +232,18 @@ class ArtificialHumanEnv:
             contribution_valid, contributor_payoff, th.zeros_like(contributor_payoff)
         )
 
-        # Compute the average payoff for each group
-        average_payoff_per_group = (
-            contributor_payoff.unsqueeze(-2) * self.agent_group_mask
-        )
+        # Per-group sum of valid contributor payoffs
+        payoff_per_group = contributor_payoff.unsqueeze(-2) * self.agent_group_mask
         contribution_valid = contribution_valid.unsqueeze(-2) * self.agent_group_mask
+        sum_payoff_per_group = payoff_per_group.sum(dim=1)
+        valid_per_group = contribution_valid.sum(dim=1)
 
-        average_payoff_per_group = average_payoff_per_group.sum(
-            dim=1
-        ) / contribution_valid.sum(dim=1)
         average_payoff_per_group = th.where(
-            contribution_valid.sum(dim=1) > 0,
-            average_payoff_per_group,
-            th.zeros_like(average_payoff_per_group),
+            valid_per_group > 0,
+            sum_payoff_per_group / valid_per_group.clamp(min=1),
+            th.zeros_like(sum_payoff_per_group),
         )
-        return contributor_payoff, average_payoff_per_group
+        return contributor_payoff, average_payoff_per_group, sum_payoff_per_group
 
     def compute_average_per_group(self, metric, valid=None):
         if valid is None:
@@ -269,8 +272,8 @@ class ArtificialHumanEnv:
 
     def update_payoff(self):
 
-        self.contributor_payoff, self.group_payoff = (
-            self.compute_average_payoff_per_group(
+        self.contributor_payoff, self.group_payoff, _ = (
+            self.compute_payoff_per_group(
                 self.contribution,
                 self.punishment,
                 self.contribution_valid,

--- a/src/aimanager/manager/environment.py
+++ b/src/aimanager/manager/environment.py
@@ -157,6 +157,9 @@ class ArtificialHumanEnv:
             "group_payoff": th.zeros(
                 (self.batch_size, self.n_groups, 1), dtype=th.float, device=self.device
             ),
+            "group_payoff_sum": th.zeros(
+                (self.batch_size, self.n_groups, 1), dtype=th.float, device=self.device
+            ),
             "does_switch": th.zeros(size, dtype=th.bool, device=self.device),
             "switch_mask": th.zeros(size, dtype=th.bool, device=self.device),
         }
@@ -272,7 +275,7 @@ class ArtificialHumanEnv:
 
     def update_payoff(self):
 
-        self.contributor_payoff, self.group_payoff, _ = (
+        self.contributor_payoff, self.group_payoff, self.group_payoff_sum = (
             self.compute_payoff_per_group(
                 self.contribution,
                 self.punishment,
@@ -282,7 +285,10 @@ class ArtificialHumanEnv:
         )
 
     def update_reward(self):
-        self.reward = self.group_payoff
+        if self.reward_mode == "sum":
+            self.reward = self.group_payoff_sum
+        else:
+            self.reward = self.group_payoff
 
     def update_contribution(self):
         contribution = self.artifical_humans.predict(

--- a/src/aimanager/simulation/simulate.py
+++ b/src/aimanager/simulation/simulate.py
@@ -179,6 +179,7 @@ def run_simulation(config: dict, output_dir: str) -> list:
             ah_switch = GraphNetwork.load(hms_path, device=device)
 
         agent_groups = config.get("agent_groups", None)
+        reward_mode = config.get("reward_mode", "sum")
 
         # Create environment
         env = ArtificialHumanEnv(
@@ -194,6 +195,7 @@ def run_simulation(config: dict, output_dir: str) -> list:
             batch_size=1,
             device=device,
             agent_groups=agent_groups,
+            reward_mode=reward_mode,
         )
 
         # Create recorder

--- a/src/aimanager/tests/test_environment.py
+++ b/src/aimanager/tests/test_environment.py
@@ -43,6 +43,7 @@ def test_multi_group_env():
         n_rounds=3,
         n_groups=2,
         device="cpu",
+        reward_mode="avg",
         default_values={
             "punishment": 0,
             "contribution": 0,
@@ -173,6 +174,7 @@ def test_artificial_human_env():
         n_punishments=3,
         n_rounds=2,
         device="cpu",
+        reward_mode="avg",
         default_values={
             "punishment": 0,
             "contribution": 0,
@@ -317,6 +319,7 @@ def _make_env(n_rounds=3):
         n_punishments=3,
         n_rounds=n_rounds,
         device="cpu",
+        reward_mode="avg",
         default_values={
             "punishment": 0,
             "contribution": 0,
@@ -364,3 +367,82 @@ def test_reward_terminal():
     assert done
     # Terminal reward should be group_payoff, NOT -avg_punishment/32
     assert th.allclose(reward, group_payoff_after_punish)
+
+
+def _make_two_group_env(reward_mode):
+    """6-agent env with asymmetric groups [4, 2] so sum != avg."""
+    default_values = {
+        "punishment": 1,
+        "contribution": 1,
+        "payoffs": 1,
+        "contribution_valid": True,
+        "common_good": 1,
+        "round_number": 1,
+        "player_id": 1,
+    }
+    env = ArtificialHumanEnv(
+        artifical_humans=MockArtificialHuman(default_values),
+        artifical_humans_valid=MockArtificialHumanValid(),
+        batch_size=1,
+        n_agents=6,
+        n_contributions=3,
+        n_punishments=3,
+        n_rounds=2,
+        n_groups=2,
+        device="cpu",
+        agent_groups=[0, 0, 0, 0, 1, 1],
+        reward_mode=reward_mode,
+        default_values={
+            "punishment": 0,
+            "contribution": 0,
+            "round_number": 0,
+            "is_first": False,
+            "contribution_valid": False,
+            "punishment_valid": False,
+            "common_good": 0,
+            "contributor_payoff": 0,
+            "manager_payoff": 0,
+            "reward": 0,
+        },
+    )
+    return env
+
+
+def test_reward_mode_sum_vs_avg():
+    """sum and avg paths log both fields; reward selects per mode."""
+    punishment = th.tensor([[[1], [0], [2], [1], [0], [2]]])
+
+    # group 0 (agents 0..3): 4 agents, contribution=1 each, punish=[1,0,2,1]
+    # group 1 (agents 4..5): 2 agents, contribution=1 each, punish=[0,2]
+    # common_good_g0 = (4*1.6 - 4) / 4 = 0.6
+    # common_good_g1 = (2*1.6 - 2) / 2 = 0.6
+    # contributor_payoff_i = 19 - p_i + cg
+    # group_0 payoffs: [18.6, 19.6, 17.6, 18.6] -> sum 74.4, avg 18.6
+    # group_1 payoffs: [19.6, 17.6]             -> sum 37.2, avg 18.6
+    expected_sum = th.tensor([[[74.4], [37.2]]])
+    expected_avg = th.tensor([[[18.6], [18.6]]])
+
+    for mode, expected_reward in (("avg", expected_avg), ("sum", expected_sum)):
+        env = _make_two_group_env(reward_mode=mode)
+        env.punish(punishment)
+
+        # Both fields logged regardless of mode
+        assert th.allclose(
+            env.group_payoff, expected_avg
+        ), f"avg field mismatch in mode={mode}"
+        assert th.allclose(
+            env.group_payoff_sum, expected_sum
+        ), f"sum field mismatch in mode={mode}"
+
+        # Reward picks the right field
+        _, reward, _ = env.step()
+        assert th.allclose(
+            reward, expected_reward
+        ), f"reward in mode={mode} expected {expected_reward}, got {reward}"
+
+
+def test_reward_mode_invalid_raises():
+    import pytest
+
+    with pytest.raises(ValueError, match="reward_mode"):
+        _make_two_group_env(reward_mode="median")


### PR DESCRIPTION
Closes #68.

## Summary

- New `reward_mode` kwarg on `ArtificialHumanEnv` selects between **sum** (new default) and **avg** of in-group contributor payoffs as the manager's reward signal. Sum rewards both per-member payoff and group size — the intended objective for the group-switching setting.
- Both fields (`group_payoff`, `group_payoff_sum`) are always logged to state, regardless of mode, so diagnostics stay comparable across runs.
- Wired through `simulate.py`; `rl_manager.py` already spreads `**env_args`, so YAMLs control the flag directly.
- Pinned `reward_mode: avg` in 5 legacy RL manager configs to preserve their original reward signal.

## Test plan

Diagnostic script run on Raven dumps both fields and the selected reward side-by-side for both modes on an asymmetric 2-group env (sizes 4, 2):

```
=== reward_mode comparison (group sizes: 4, 2) ===
punishment        : [1, 0, 2, 1, 0, 2]
expected avg/grp  : [18.6, 18.6]
expected sum/grp  : [74.4, 37.2]

--- reward_mode='avg' ---
  state['group_payoff']     (avg) = [18.6, 18.6]
  state['group_payoff_sum']       = [74.4, 37.2]
  reward returned by step()       = [18.6, 18.6]
  avg field correct : True
  sum field correct : True
  reward selects avg : True

--- reward_mode='sum' ---
  state['group_payoff']     (avg) = [18.6, 18.6]
  state['group_payoff_sum']       = [74.4, 37.2]
  reward returned by step()       = [74.4, 37.2]
  avg field correct : True
  sum field correct : True
  reward selects sum : True
```

Reproduce: `ssh raven 'cd ~/algorithmic-institutions && source .venv/bin/activate && python scripts/tests/diagnose_reward_mode.py'`

Unit tests on Raven: `pytest src/aimanager/tests/test_environment.py -v` → 6/6 passed (4 pre-existing + 2 new: `test_reward_mode_sum_vs_avg`, `test_reward_mode_invalid_raises`).