### PR TITLE
Fix group-switching preprocessing/training data bugs (#105)

### DIFF
--- a/artifacts/artificial_humans/punishment_rnn_edge_50ep_doubled/confusion_matrix/architecture_node+edge+rnn__dataset_50ep_doubled.parquet
+++ b/artifacts/artificial_humans/punishment_rnn_edge_50ep_doubled/confusion_matrix/architecture_node+edge+rnn__dataset_50ep_doubled.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1b7bf6568908afe256dd9e56696e2af86d89e0b4638f25d9d6e5fb7525c9d3f7
-size 4235859
+oid sha256:839c214e46bdbbb0ffa48b2a9dd9f22a166e5e5656b666957e43ee91a50a9bb9
+size 2500022

--- a/artifacts/artificial_humans/punishment_rnn_edge_50ep_doubled/metrics/architecture_node+edge+rnn__dataset_50ep_doubled.parquet
+++ b/artifacts/artificial_humans/punishment_rnn_edge_50ep_doubled/metrics/architecture_node+edge+rnn__dataset_50ep_doubled.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ee5a4585c8e9e22ef8d4d6bc3c0ffda2c80cc19885bae448f2668f1c7d7bb9b7
-size 52382
+oid sha256:3301de41c4a9021f07fb253051486779d645c103828bf6fbefb2026a019651cd
+size 67546

--- a/artifacts/artificial_humans/punishment_rnn_edge_50ep_doubled/model/architecture_node+edge+rnn__dataset_50ep_doubled.pt
+++ b/artifacts/artificial_humans/punishment_rnn_edge_50ep_doubled/model/architecture_node+edge+rnn__dataset_50ep_doubled.pt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2fcba4f3e61478558edb0a542f695c5e45f610f4fcb3e3455c366fd559bc0bda
+oid sha256:af90101a02752cb2ff1772c03e684722e34bf993be5a5d0146db4c1746cbdcff
 size 21203

--- a/artifacts/artificial_humans/switch_pred_opt_50ep_doubled/confusion_matrix/architecture_mlp+rnn+edge__dataset_50ep_doubled.parquet
+++ b/artifacts/artificial_humans/switch_pred_opt_50ep_doubled/confusion_matrix/architecture_mlp+rnn+edge__dataset_50ep_doubled.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ec28c6ad3a916fb067dee04f9badc9b6da689cbb887fc6ce1c1536bfd158f15
-size 284777
+oid sha256:146b58025dc4f8dcb0dbc80efd2c3a79256bac2dfba394b850be270a138919a3
+size 284323

--- a/artifacts/artificial_humans/switch_pred_opt_50ep_doubled/metrics/architecture_mlp+rnn+edge__dataset_50ep_doubled.parquet
+++ b/artifacts/artificial_humans/switch_pred_opt_50ep_doubled/metrics/architecture_mlp+rnn+edge__dataset_50ep_doubled.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:668eb9da7a5876b23777e991f824e0766ed3b8c08ad3ab103b959d0d0e22c007
-size 30748
+oid sha256:a0caea0092b412b113eade0a2e68e41e910ccdaa4548d82d548fe38998f7a70e
+size 95793

--- a/artifacts/artificial_humans/switch_pred_opt_50ep_doubled/model/architecture_mlp+rnn+edge__dataset_50ep_doubled.pt
+++ b/artifacts/artificial_humans/switch_pred_opt_50ep_doubled/model/architecture_mlp+rnn+edge__dataset_50ep_doubled.pt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:47b4478c0cab77b3015b10fed570043e721e70eef548e1564de5fcede0a22808
-size 18835
+oid sha256:cf850f462482518f137d24bfd674301efe8d0d4ab44dd19f31950ffc601f9487
+size 9875

--- a/configs/training/artificial_humans/punishment/rnn_edge_50ep_doubled.yml
+++ b/configs/training/artificial_humans/punishment/rnn_edge_50ep_doubled.yml
@@ -15,7 +15,7 @@ params_only: true
 params:
   fraction_training: 1.0
   seed: 38381
-  mask_name: recorded
+  mask_name: punishment_valid
   switch_every: 4
   experiment_names: [ah_group_switching]
   labels:

--- a/configs/training/artificial_humans/switch_predictor/opt_50ep_doubled.yml
+++ b/configs/training/artificial_humans/switch_predictor/opt_50ep_doubled.yml
@@ -1,10 +1,10 @@
 description: >-
-  Switch predictor retrained on the pair-augmented (doubled) 50-episode
-  dataset to remove the alphabetical governorA→group_id=0 bias. Every
-  competition appears with both label-to-group_id mappings; CV groups
-  paired copies into the same fold (see get_cross_validations
-  group_key). All hyperparameters mirror opt_50ep.yml so test log-loss
-  is directly comparable.
+  Switch predictor on the pair-augmented (doubled) 50-episode dataset.
+  #105 fixes: labels at the arrival round (aligned with env consumption),
+  prev_agent_group feature, mask_name=switch_valid (drops timeout stays).
+  Model hidden 10 + lr 5e-4 + round_number feature to balance the
+  overfitting (hidden 20 / lr 1e-3) and underfitting (hidden 5 / lr 1e-4)
+  extremes.
 exec:
   command: python -m aimanager train-ah {job_file}
   script_name: run_training
@@ -16,7 +16,7 @@ params_only: true
 params:
   fraction_training: 1.0
   seed: 38381
-  mask_name: switch_mask
+  mask_name: switch_valid
   switch_every: 4
   experiment_names: [ah_group_switching]
   labels:
@@ -29,12 +29,14 @@ params:
   n_groups: 2
   data_file: experiments/2group_8agent_50ep.csv
   model_name: graph
+  shuffle_features:
+    [prev_common_good, prev_punishment, prev_agent_group, round_number]
   basedir: .
   output_dir: artifacts/artificial_humans/switch_pred_opt_50ep_doubled
   model_args:
     y_levels: 2
     y_name: does_switch
-    hidden_size: 20
+    hidden_size: 10
     add_rnn: True
     add_edge_model: True
     add_global_model: False
@@ -45,11 +47,14 @@ params:
       - name: prev_punishment
         n_levels: 31
         encoding: numeric
-      - name: agent_group
+      - name: prev_agent_group
         n_levels: 2
         encoding: numeric
+      - name: round_number
+        n_levels: 24
+        encoding: numeric
   optimizer_args:
-    lr: 1.e-3
+    lr: 5.e-4
     weight_decay: 1.e-3
   train_args:
     epochs: 375

--- a/experiments/2group_8agent_50ep.csv
+++ b/experiments/2group_8agent_50ep.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:427b01b64d4625f690b244c0467dfd80bf2e70c2af219a3d88d585627d646957
-size 1869718
+oid sha256:27c6bdbe417d487461ce1fe2db6e81c5df8bff50a5c8d8f260c3e9b2daf0517a
+size 2019406

--- a/experiments/2group_8agent_50ep.csv
+++ b/experiments/2group_8agent_50ep.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:73b59d002866571d3ab47d82f5632d2ee70ba7a5e047f560c2b865d15fed94f7
+oid sha256:d3c0a76e226f888ff1800df3fd9f0dba26eb50af54cbd22d0669cdd9fea66b76
 size 1831300

--- a/experiments/2group_8agent_50ep.csv
+++ b/experiments/2group_8agent_50ep.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d3c0a76e226f888ff1800df3fd9f0dba26eb50af54cbd22d0669cdd9fea66b76
-size 1831300
+oid sha256:427b01b64d4625f690b244c0467dfd80bf2e70c2af219a3d88d585627d646957
+size 1869718

--- a/scripts/data_creation/group_switching_preprocess.py
+++ b/scripts/data_creation/group_switching_preprocess.py
@@ -77,9 +77,20 @@ def _preprocess_single(in_path: str, n_agents: int):
         ]
 
         round_number = round_raw - 1
-        manager_no_input = int(
-            bool(row.get("missing_governor_input", False))
-        )
+        # Per-governor missing-input flags. Each governor manages one
+        # group label; sorted labels map to the flag columns in order
+        # (governorA -> missing_governor_input, governorB ->
+        # missing_governor2_input). Verified against the raw data: when
+        # a governor's flag is set, his group's punishments are all 0
+        # while the other group's punishments are real.
+        governor_flag_cols = [
+            "missing_governor_input",
+            "missing_governor2_input",
+        ]
+        label_manager_no_input = {
+            label: int(bool(row.get(col, False)))
+            for label, col in zip(labels, governor_flag_cols)
+        }
 
         for aug_idx, group_label_to_idx in enumerate(mappings):
             aug_suffix = "" if aug_idx == 0 else " (flipped)"
@@ -125,7 +136,9 @@ def _preprocess_single(in_path: str, n_agents: int):
                         "player_no_input": int(
                             bool(missing_inputs[player_id])
                         ),
-                        "manager_no_input": manager_no_input,
+                        "manager_no_input": label_manager_no_input.get(
+                            groups_list[player_id], 0
+                        ),
                         "player_id": player_id,
                         "contribution": float(contributions[player_id]),
                         "punishment": float(punishments[player_id]),

--- a/scripts/data_creation/group_switching_preprocess.py
+++ b/scripts/data_creation/group_switching_preprocess.py
@@ -30,6 +30,13 @@ def _preprocess_single(in_path: str, n_agents: int):
     df["missing_inputs_list"] = df["missing_inputs"].apply(_parse_list)
     df["participant_codes_list"] = df["participant_codes"].apply(_parse_list)
     df["groups_list"] = df["groups"].apply(_parse_list)
+    # Per-agent institution-choice timeout flag (True => the agent's
+    # group choice timed out and defaulted to "stay"). Logged at the
+    # choice/arrival round; downstream (data.py) aligns it to the
+    # does_switch label index to build switch_valid.
+    df["selection_timeout_list"] = df["institution_selection_timeout"].apply(
+        _parse_list
+    )
 
     # Keep only rounds with the expected number of agents.
     has_n_agents = df["contributions_list"].apply(len) == n_agents
@@ -59,6 +66,7 @@ def _preprocess_single(in_path: str, n_agents: int):
         missing_inputs = row["missing_inputs_list"]
         participant_codes = row["participant_codes_list"]
         groups_list = row["groups_list"]
+        selection_timeout = row["selection_timeout_list"]
 
         # One pair per competition (session + group_idx). Both
         # augmentations of a competition share its pair_id.
@@ -94,9 +102,7 @@ def _preprocess_single(in_path: str, n_agents: int):
 
         for aug_idx, group_label_to_idx in enumerate(mappings):
             aug_suffix = "" if aug_idx == 0 else " (flipped)"
-            aug_global_group_id = (
-                f"{session} #{competition_idx}{aug_suffix}"
-            )
+            aug_global_group_id = f"{session} #{competition_idx}{aug_suffix}"
             # Distinct episode_id per augmentation; the global_group_id
             # split alone is enough for downstream tensor-row uniqueness
             # but giving each a unique episode_id keeps groupby keys
@@ -133,11 +139,14 @@ def _preprocess_single(in_path: str, n_agents: int):
                         "experiment_name": "ah_group_switching",
                         "round_number": round_number,
                         "participant_code": participant_codes[player_id],
-                        "player_no_input": int(
-                            bool(missing_inputs[player_id])
-                        ),
+                        "player_no_input": int(bool(missing_inputs[player_id])),
                         "manager_no_input": label_manager_no_input.get(
                             groups_list[player_id], 0
+                        ),
+                        "selection_timeout": (
+                            int(bool(selection_timeout[player_id]))
+                            if selection_timeout
+                            else 0
                         ),
                         "player_id": player_id,
                         "contribution": float(contributions[player_id]),
@@ -162,6 +171,7 @@ COLS = [
     "participant_code",
     "player_no_input",
     "manager_no_input",
+    "selection_timeout",
     "player_id",
     "contribution",
     "punishment",
@@ -208,13 +218,12 @@ def main(
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    parser.add_argument(
-        "in_paths", nargs="+", help="One or more wide-format CSVs"
-    )
+    parser.add_argument("in_paths", nargs="+", help="One or more wide-format CSVs")
     parser.add_argument(
         "--n_agents",
         help="Number of agents active in each round to filter for",
-        type=int, required=True,
+        type=int,
+        required=True,
     )
     parser.add_argument("--out_path", type=str, default=None)
     args = parser.parse_args()

--- a/scripts/data_creation/group_switching_preprocess.py
+++ b/scripts/data_creation/group_switching_preprocess.py
@@ -109,9 +109,12 @@ def _preprocess_single(in_path: str, n_agents: int):
             # clean.
             aug_episode_id = pair_id * 2 + aug_idx
 
-            # Per-group common good (depends on the mapping).
+            # Per-group common good (depends on the mapping). common_good
+            # is stored as the group pool; per-capita (pool / valid
+            # contributors) is used for the payoff.
             group_contrib = {}
             group_punish = {}
+            group_n_valid = {}
             for pid in range(n_agents):
                 gidx = group_label_to_idx[groups_list[pid]]
                 is_valid = not bool(missing_inputs[pid])
@@ -120,11 +123,16 @@ def _preprocess_single(in_path: str, n_agents: int):
                     group_punish.setdefault(gidx, 0.0)
                     group_contrib[gidx] += contributions[pid]
                     group_punish[gidx] += punishments[pid]
+                    group_n_valid[gidx] = group_n_valid.get(gidx, 0) + 1
             common_good_per_group = {}
+            common_good_per_capita = {}
             for gidx in set(group_label_to_idx.values()):
                 sc = group_contrib.get(gidx, 0.0)
                 sp = group_punish.get(gidx, 0.0)
-                common_good_per_group[gidx] = sc * 1.6 - sp
+                pool = sc * 1.6 - sp
+                nv = group_n_valid.get(gidx, 0)
+                common_good_per_group[gidx] = pool
+                common_good_per_capita[gidx] = pool / nv if nv > 0 else 0.0
 
             for player_id in range(n_agents):
                 gidx = group_label_to_idx[groups_list[player_id]]
@@ -151,7 +159,12 @@ def _preprocess_single(in_path: str, n_agents: int):
                         "player_id": player_id,
                         "contribution": float(contributions[player_id]),
                         "punishment": float(punishments[player_id]),
-                        "payoff": 0.0,
+                        "payoff": (
+                            20
+                            - float(contributions[player_id])
+                            - float(punishments[player_id])
+                            + common_good_per_capita[gidx]
+                        ),
                         "common_good": common_good_per_group[gidx],
                     }
                 )

--- a/src/aimanager/generic/data.py
+++ b/src/aimanager/generic/data.py
@@ -32,6 +32,7 @@ class AgentRound(pa.DataFrameModel):
     agent_group: Series[int]
     does_switch: Series[bool]
     switch_mask: Series[bool]
+    switch_valid: Series[bool]
 
 
 def parse_agent_rounds(df, switch_every=None):
@@ -47,18 +48,31 @@ def parse_agent_rounds(df, switch_every=None):
     # sub-group membership (node feature for GNN)
     df["agent_group"] = df["group_id"].astype(int)
 
-    # does_switch: True if agent changes group_id next round
+    # does_switch labelled at the arrival round (group changed vs the
+    # previous round), so the supervised index matches where the env
+    # consumes the predictor. Pair with prev_agent_group in the model.
     df = df.sort_values(["episode_id", "player_id", "round_number"])
-    next_group = df.groupby(["episode_id", "player_id"])["group_id"].shift(-1)
-    df["does_switch"] = next_group.notna() & next_group.ne(df["group_id"])
+    prev_group = df.groupby(["episode_id", "player_id"])["group_id"].shift(1)
+    df["does_switch"] = prev_group.notna() & prev_group.ne(df["group_id"])
 
-    # Mask non-decision rounds when switch_every is set
+    # Decisions land on arrival rounds {switch_every, 2*switch_every, ...};
+    # round 0 is the initial assignment, not a decision.
     if switch_every is not None:
-        is_decision = (df["round_number"] + 1) % switch_every == 0
+        is_decision = (df["round_number"] % switch_every == 0) & (
+            df["round_number"] != 0
+        )
         df["does_switch"] = df["does_switch"] & is_decision
         df["switch_mask"] = is_decision
     else:
         df["switch_mask"] = True
+
+    # switch_valid: drop decisions whose group choice timed out.
+    if "selection_timeout" in df.columns:
+        df["switch_valid"] = df["switch_mask"] & (
+            df["selection_timeout"].fillna(0).astype(int) == 0
+        )
+    else:
+        df["switch_valid"] = df["switch_mask"]
 
     # episode-batch index (tensor's first dimension)
     episode_group = df["global_group_id"] + "__" + df["episode_id"].astype(str)
@@ -100,6 +114,7 @@ def get_default_values(df):
         "agent_group": 0,
         "does_switch": False,
         "switch_mask": False,
+        "switch_valid": False,
     }
     return default_values
 
@@ -120,6 +135,7 @@ def create_torch_data_new(df, default_values=None):
         "agent_group": th.int64,
         "does_switch": th.bool,
         "switch_mask": th.bool,
+        "switch_valid": th.bool,
     }
 
     n_groups = df["group_idx"].max() + 1
@@ -153,8 +169,8 @@ def create_torch_data_new(df, default_values=None):
     if "pair_id" in df.columns:
         pair_id = (
             df.drop_duplicates("group_idx")
-              .sort_values("group_idx")["pair_id"]
-              .to_numpy()
+            .sort_values("group_idx")["pair_id"]
+            .to_numpy()
         )
     else:
         pair_id = np.arange(n_groups)
@@ -196,8 +212,7 @@ def get_cross_validations(
                 group_to_indices[k].append(idx)
             fold_groups = [order[i::n_splits] for i in range(n_splits)]
             groups = [
-                [idx for k in fg for idx in group_to_indices[k]]
-                for fg in fold_groups
+                [idx for k in fg for idx in group_to_indices[k]] for fg in fold_groups
             ]
         else:
             groups = [episode_idx[i::n_splits] for i in range(n_splits)]


### PR DESCRIPTION
Fixes the data-handling bugs found in #105. Three scoped commits:

- **Governor-2 flag**: `manager_no_input` now maps each player to the governor of its group (was reading only `missing_governor_input` for all 8); punishment AH masks on `punishment_valid`.

- **Switch labels**: aligns data creation with how the predictor is actually used.
  - *Before*: preprocessing/`data.py` labeled `does_switch[t]` by comparing each round to the **next** round and masked decisions at rounds `{3,7,11,15,19,23}` — i.e. one round *before* the group actually changes. But the env queries the switch predictor at the **arrival** rounds `{4,8,12,16,20}` (`round_number % switch_every == 0`). So the model was supervised at timesteps it is never queried at and vice versa (disjoint sets), the feature window missed the last round of each block, round 23 was a phantom decision (no round 24 to switch into) contributing 1/6 all-stay labels, and timeout-forced "stay" choices were trained as genuine stays.
  - *Now*: labels sit on the arrival round (`group[t] != group[t-1]`, mask `{4,8,12,16,20}`), so training matches the env's query timestep round-for-round. The group feature is `prev_agent_group` (the pre-switch group the env sees at decision time, not the post-switch group recorded at arrival, which would leak the label), and `switch_valid` drops the 218 timeout-forced stays. Switch AH retrained.

- **Payoff**: computed in preprocess instead of hardcoded 0.0.

Affected AH artifacts (punishment, switch) retrained on the corrected data.

Closes #105.