### PR TITLE
Implement the C/S/P evaluation metrics (#128)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ models/
 
 # Cache files
 *_cache.pkl
+src/aimanager/evaluation_suite/examples/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,7 @@ scripts/remote_test.sh -- -k test_encoder -v
 - **Train AH models**: `python -m aimanager train-ah <config>`
 - **Train RL manager**: `python -m aimanager train-manager <config>`
 - **Run simulation**: `python -m aimanager simulate <config>`
+- **Evaluate sim vs human**: `python -m aimanager evaluate <config>` (needs the simulation's `per_round.parquet`)
 - **Plot confusion matrix**: `python scripts/plotting/plot_confusion_matrix.py <artifact_dir>`
 
 ### Where to Find Things

--- a/notes/evaluation_metric_defs.md
+++ b/notes/evaluation_metric_defs.md
@@ -1,0 +1,153 @@
+# Definitions of Evaluation Metrics
+
+Metrics for issue #128: we simulate many episodes with trained models and compare
+the statistics of the simulation against the human experiment. Every metric is
+computed once on the human data and once on the simulated data; the score says
+how far apart the two are. Rollouts involve three models (manager, contribution,
+switching), so credit cannot be cleanly assigned -- C rows say the most about the
+contribution model, S rows about the switching model, P rows about the manager.
+The P rows only score managers that are meant to mimic human punishment; for an
+RL manager they describe the policy rather than score it.
+
+## Shared conventions
+
+- **Human reference data:** `experiments/2group_8agent_50ep.csv`. Every real game
+  appears twice in the file with group labels swapped (the flip augmentation);
+  we keep one copy per game, same as the linear-model training pipeline.
+- **No-input rows:** rounds where a player or manager did not respond in time are
+  excluded, same as the masking used in training.
+- **Switching:** derived from group membership changes and anchored to the
+  decision round (3, 7, 11, 15, 19). Human decisions with a selection timeout
+  are excluded from switching denominators (the `switch_valid` policy from
+  training). The simulation has no timeouts, so all its opportunities are valid.
+- **Empty groups:** a (game, round) where all players sit in one group. Each
+  metric below states how it handles this. Metrics over individual players are
+  not affected (the players in the surviving group still count); metrics that
+  need both groups drop the round; SC keeps these rounds on purpose.
+- **`common_good`** is not used by any metric and is excluded from the common
+  data format.
+
+## Score types
+
+Each metric has exactly one canonical score. Three score types exist:
+
+1. **abs Δ statistic** -- absolute difference between the human value and the sim
+   value of a statistic. When the metric is "per X" (round, opportunity, bin),
+   the difference is computed per stratum and the strata are averaged with
+   weights equal to each stratum's human frequency, fixed once from the full
+   deduped human data (issue #132's scoring schema; for round strata this is
+   close to uniform because rounds are roughly equally populated).
+2. **signed Δ std** -- sim standard deviation minus human standard deviation,
+   reported signed and in raw units. Diagnostic only, never a canonical score;
+   kept for exactly three rows (CA, CC, CE).
+3. **EMD** -- earth mover's distance between the human and sim distributions
+   (`scipy.stats.wasserstein_distance`).
+
+Whenever a canonical score says "per X, averaged", the average uses the same
+human-frequency stratum weights, regardless of whether the per-stratum value is
+an abs Δ or an EMD.
+
+## Contribution distributions (C)
+
+**CA -- participant mean contributions:** each participant's average contribution
+over their rounds; how much participants differ from each other.
+Canonical: EMD. Diagnostic: signed Δ std. Empty groups: not affected.
+
+**CB -- round mean contributions:** the average contribution in each of the 24
+rounds; how contributions rise and fall over the game.
+Canonical: abs Δ per round, averaged over the 24 rounds. Empty groups: not affected.
+
+**CC -- group mean contributions:** the average contribution of each group in
+each (game, round); how much groups differ from each other.
+Canonical: EMD. Diagnostic: signed Δ std. Empty groups: an empty group has no
+mean and produces no observation; the surviving group's mean is kept.
+
+**CD -- raw contributions:** every single contribution, pooled; the natural
+shape of contribution behavior.
+Canonical: EMD. Empty groups: not affected.
+
+**CE -- signed group contribution differences:** for each (game, round), group
+0's mean contribution minus group 1's; how far the two groups of a game drift apart.
+Canonical: EMD. Diagnostic: signed Δ std. Empty groups: the whole (game, round)
+drops, because the difference needs both groups.
+
+**CF -- boundary shares:** the share of contributions equal to 0 and the share
+equal to 20, per round; how much behavior polarizes at the extremes.
+Canonical: abs Δ per (round, boundary) cell, averaged over the 48 cells.
+Empty groups: not affected.
+
+## Switching distributions (S)
+
+**SA -- overall switch rate:** the share of valid switching opportunities where
+the player actually switched, all opportunities pooled.
+Canonical: abs Δ of the two rates. Empty groups: not affected.
+
+**SB -- switch rate per opportunity:** the same rate computed separately at each
+of the 5 decision rounds (3, 7, 11, 15, 19); when in the game people switch.
+Canonical: abs Δ per opportunity, averaged over the 5. Empty groups: not affected.
+
+**SC -- size of the larger group:** for every (game, round) from round 4 on, the
+number of players in the larger group (4 means balanced, 8 means everyone
+together); how segregated games become.
+Canonical: EMD. Empty groups: KEPT -- a larger-group size of 8 is the strongest
+segregation signal and dropping it would censor exactly what SC measures.
+Rounds 0-3 are excluded because groups are always 4-4 before the first switch.
+
+## Punishment distributions (P)
+
+**PA -- raw punishments:** every single received punishment, pooled, zeros
+included; the natural shape of punishment behavior.
+Canonical: EMD. Empty groups: not affected.
+
+**PB -- mean punishment per round:** the average punishment received in each of
+the 24 rounds; how punishment intensity develops over the game.
+Canonical: abs Δ per round, averaged over the 24 rounds. Empty groups: not affected.
+
+**PC -- share of zero punishments per round:** the share of players who received
+no punishment in each round; whether the manager punishes at all, as opposed to
+how much.
+Canonical: abs Δ per round, averaged over the 24 rounds. Empty groups: not affected.
+
+## Responses (R) -- documented here, implemented on a later branch
+
+A response is conditioned on the stimulus it reacts to: these check whether the
+models have the right mechanisms, not just the right states. Contribution change
+means next round's contribution minus this round's, with the stimulus taken this
+round. The R rows can have empty strata (a sim that never punishes or never
+switches produces no observations in some bins); how to handle that is decided
+on the R branch.
+
+**RCA -- contribution change by round type:** how contributions change after four
+kinds of round: no switch was allowed, the player switched, the player chose to
+stay, the player stayed but their group's composition changed.
+Canonical: EMD per round type, averaged over the 4 types.
+
+**RCB -- reaction to punishment:** the average contribution change of punished
+non-full contributors, split by punishment rate bins (0, 0.25], (0.25, 0.5],
+(0.5, 1], > 1; how strongly people respond to being punished.
+Canonical: abs Δ per bin, averaged over the 4 bins.
+
+**RCC -- reaction at the ceiling:** among full contributors (gave 20), the average
+contribution change of punished minus unpunished players; RCB's rate is
+undefined at 20, so the ceiling gets its own contrast.
+Canonical: abs Δ of the punished-minus-unpunished contrast.
+
+**RCD -- switching pull:** for each switch, regress the switcher's contribution
+change on the gap between the receiving group's mean contribution and their own;
+whether switchers adapt toward their new group.
+Canonical: abs Δ of the regression slope (the pull coefficient).
+
+**RSA -- switching after punishment:** the share of punished players who switch
+at the next opportunity, split by punishment size bins 1-3, 4-15, 16+; who
+leaves after being punished.
+Canonical: abs Δ per bin, averaged over the 3 bins.
+
+**RPA -- the manager's policy:** the distribution of punishments given at each
+contribution level bin {0}, 1-5, 6-10, 11-15, 16-19, {20}; how punishment
+depends on what the player contributed.
+Canonical: EMD per bin, averaged over the 6 bins.
+
+**RPB -- punishment by group size:** the distribution of punishments in group
+size bins 1-3, 4-5, 6-8, from round 4 on; whether punishment depends on how
+many players the manager governs. Empty groups drop out by construction.
+Canonical: EMD per bin, averaged over the 3 bins.

--- a/notes/evaluation_metric_defs.md
+++ b/notes/evaluation_metric_defs.md
@@ -33,18 +33,20 @@ Each metric has exactly one canonical score. Three score types exist:
 
 1. **abs Δ statistic** -- absolute difference between the human value and the sim
    value of a statistic. When the metric is "per X" (round, opportunity, bin),
-   the difference is computed per stratum and the strata are averaged with
-   weights equal to each stratum's human frequency, fixed once from the full
-   deduped human data (issue #132's scoring schema; for round strata this is
-   close to uniform because rounds are roughly equally populated).
+   the difference is computed per stratum and the strata are averaged. Strata
+   fixed by the game design (rounds, boundary cells, switching opportunities --
+   every C/S/P statistic row) use uniform precomputed weights; strata
+   conditioned on behaviour (the R bins) use weights equal to each stratum's
+   human frequency, fixed once from the full deduped human data (issue #132).
 2. **signed Δ std** -- sim standard deviation minus human standard deviation,
    reported signed and in raw units. Diagnostic only, never a canonical score;
    kept for exactly three rows (CA, CC, CE).
 3. **EMD** -- earth mover's distance between the human and sim distributions
    (`scipy.stats.wasserstein_distance`).
 
-Whenever a canonical score says "per X, averaged", the average uses the same
-human-frequency stratum weights, regardless of whether the per-stratum value is
+Whenever a canonical score says "per X, averaged", the average uses the row's
+weight scheme (uniform for design-fixed strata, human-frequency for
+behaviour-conditioned strata), regardless of whether the per-stratum value is
 an abs Δ or an EMD.
 
 ## Contribution distributions (C)

--- a/plots/simulation/22_2g8a_linear_self_ridge_contr/metrics.csv
+++ b/plots/simulation/22_2g8a_linear_self_ridge_contr/metrics.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc13be6994de9d88ffc3b4545e3b0dfabb22f66fa75c944ebae296ef884ad18f
+size 3452

--- a/src/aimanager/cli.py
+++ b/src/aimanager/cli.py
@@ -4,6 +4,7 @@ Usage:
     python -m aimanager train-ah <config>
     python -m aimanager train-manager <config>
     python -m aimanager simulate <config>
+    python -m aimanager evaluate <config>
 """
 
 import argparse
@@ -29,6 +30,14 @@ REQUIRED_KEYS = {
         "n_update_steps",
     ],
     "simulate": [
+        "artificial_humans",
+        "managers",
+        "n_episodes",
+        "n_episode_steps",
+    ],
+    # evaluate reads a finished simulation's output, so it takes the
+    # same simulation config
+    "evaluate": [
         "artificial_humans",
         "managers",
         "n_episodes",
@@ -100,10 +109,17 @@ def dispatch_simulate(config, config_path):
     run_cli(config, config_path)
 
 
+def dispatch_evaluate(config, config_path):
+    from aimanager.evaluation_suite.evaluate import run_cli
+
+    run_cli(config, config_path)
+
+
 DISPATCH = {
     "train-ah": dispatch_train_ah,
     "train-manager": dispatch_train_manager,
     "simulate": dispatch_simulate,
+    "evaluate": dispatch_evaluate,
 }
 
 

--- a/src/aimanager/evaluation_suite/convert.py
+++ b/src/aimanager/evaluation_suite/convert.py
@@ -1,0 +1,153 @@
+"""Convert simulation output and human experiment data into one canonical
+agent-round format for the evaluation suite (#128).
+
+Canonical frame, one row per (episode, participant, round):
+
+    episode_id        int64    game identifier, unique within the frame
+    participant_code  str      participant identifier, unique within the frame
+    round_number      int64    0..23
+    group_id          int64    membership at this round (0 or 1)
+    contribution      float64  0..20; NaN where the player gave no input
+    punishment        float64  0..30 received; NaN where the manager gave
+                               no input
+    does_switch       bool     True at a decision round whose choice was
+                               a switch
+    switch_mask       bool     True at decision rounds (rounds 3, 7, 11, 15,
+                               19 with switch_every=4)
+    switch_valid      bool     switch_mask minus timed-out human choices;
+                               identical to switch_mask for the simulation
+
+`common_good` and `payoff` are excluded: no metric uses them, and
+`common_good` is stored on different scales in the two sources (per-capita
+in the simulation, per-group pool in the human CSVs).
+
+Human games appear twice in the CSVs with group labels swapped (the flip
+augmentation); `load_human` keeps one copy per game. No-input and timeout
+semantics mirror the training pipeline (generic/data.py::parse_agent_rounds).
+
+Running this module as a script dumps small converted examples of both
+sources to examples/ (gitignored) for eyeballing.
+"""
+
+from pathlib import Path
+
+import pandas as pd
+import pandera as pa
+from pandera.typing import Series
+
+HUMAN_DATA_FILE = "experiments/2group_8agent_50ep.csv"
+SIM_EXAMPLE_FILE = "plots/simulation/22_2g8a_linear_self_ridge_contr/per_round.parquet"
+
+CANONICAL_COLUMNS = [
+    "episode_id",
+    "participant_code",
+    "round_number",
+    "group_id",
+    "contribution",
+    "punishment",
+    "does_switch",
+    "switch_mask",
+    "switch_valid",
+]
+
+
+class CanonicalAgentRound(pa.DataFrameModel):
+    episode_id: Series[int]
+    participant_code: Series[str]
+    round_number: Series[int]
+    group_id: Series[int]
+    contribution: Series[float] = pa.Field(nullable=True, ge=0, le=20)
+    punishment: Series[float] = pa.Field(nullable=True, ge=0, le=30)
+    does_switch: Series[bool]
+    switch_mask: Series[bool]
+    switch_valid: Series[bool]
+
+
+def _derive_switching(df, switch_every):
+    """Mirror of generic/data.py::parse_agent_rounds' switch labelling.
+
+    does_switch sits at the DECISION round s (the round played right before
+    each arrival); the membership change realises between s and s+1. The
+    episode's last round has no following arrival, so it is never a decision
+    row. selection_timeout is logged at the arrival round s+1 and aligned
+    back to the decision row.
+    """
+    df = df.sort_values(["episode_id", "participant_code", "round_number"])
+    by_player = df.groupby(["episode_id", "participant_code"])
+    next_group = by_player["group_id"].shift(-1)
+    is_decision = ((df["round_number"] + 1) % switch_every == 0) & next_group.notna()
+    switches = next_group.notna() & next_group.ne(df["group_id"])
+    df["does_switch"] = (switches & is_decision).astype(bool)
+    df["switch_mask"] = is_decision.astype(bool)
+    if "selection_timeout" in df.columns:
+        next_timeout = by_player["selection_timeout"].shift(-1)
+        df["switch_valid"] = df["switch_mask"] & (
+            next_timeout.fillna(0).astype(int) == 0
+        )
+    else:
+        df["switch_valid"] = df["switch_mask"]
+    return df
+
+
+def _finalize(df):
+    df = df.astype(
+        {
+            "episode_id": "int64",
+            "round_number": "int64",
+            "group_id": "int64",
+            "contribution": "float64",
+            "punishment": "float64",
+        }
+    )
+    df = (
+        df[CANONICAL_COLUMNS]
+        .sort_values(["episode_id", "participant_code", "round_number"])
+        .reset_index(drop=True)
+    )
+    CanonicalAgentRound(df)
+    return df
+
+
+def load_human(csv_path, switch_every=4):
+    """Human experiment CSV -> canonical frame."""
+    df = pd.read_csv(csv_path)
+    if "pair_id" in df.columns:
+        keep = df.groupby("pair_id")["episode_id"].transform("min")
+        df = df[df["episode_id"] == keep].copy()
+    df["contribution"] = df["contribution"].where(df["player_no_input"] == 0)
+    df["punishment"] = df["punishment"].where(df["manager_no_input"] == 0)
+    df = _derive_switching(df, switch_every)
+    return _finalize(df)
+
+
+def load_sim(parquet_path, switch_every=4):
+    """Simulation per_round.parquet -> {run name: canonical frame}, one per
+    pairing. episode/participant_code are already unique within a run."""
+    df = pd.read_parquet(parquet_path)
+    out = {}
+    for run, run_df in df.groupby("run"):
+        run_df = run_df.rename(columns={"episode": "episode_id"})
+        run_df = _derive_switching(run_df, switch_every)
+        out[run] = _finalize(run_df)
+    return out
+
+
+if __name__ == "__main__":
+    repo = Path(__file__).resolve().parents[3]
+    example_dir = Path(__file__).parent / "examples"
+    example_dir.mkdir(exist_ok=True)
+
+    human = load_human(repo / HUMAN_DATA_FILE)
+    episodes = sorted(human["episode_id"].unique())[:2]
+    human_example = human[human["episode_id"].isin(episodes)]
+    human_example.to_csv(example_dir / "human_example.csv", index=False)
+
+    sims = load_sim(repo / SIM_EXAMPLE_FILE)
+    run = sorted(sims)[0]
+    sim = sims[run]
+    episodes = sorted(sim["episode_id"].unique())[:2]
+    sim_example = sim[sim["episode_id"].isin(episodes)]
+    sim_example.to_csv(example_dir / "sim_example.csv", index=False)
+
+    print(f"human_example.csv: {human_example.shape} from {HUMAN_DATA_FILE}")
+    print(f"sim_example.csv: {sim_example.shape} from run '{run}'")

--- a/src/aimanager/evaluation_suite/evaluate.py
+++ b/src/aimanager/evaluation_suite/evaluate.py
@@ -1,0 +1,78 @@
+"""Evaluation-suite main script (#128).
+
+    python -m aimanager evaluate <simulation config>
+
+Reads the finished simulation's per_round.parquet from the config's
+output_dir (the simulation must have run with save_per_round: true),
+converts the human reference and every pairing into the canonical frame,
+and writes metrics.csv to the output_dir -- one row per (pairing, metric)
+with the raw discrepancy d(human, sim), the signed std diagnostic where
+retained (CA/CC/CE), and the observation counts. These are raw-unit
+quick-look values; the comparable normalised scores come from #132's
+scoring pipeline, which consumes the metric objects directly.
+"""
+
+import os
+import sys
+
+import pandas as pd
+
+from aimanager.evaluation_suite.convert import (
+    HUMAN_DATA_FILE,
+    load_human,
+    load_sim,
+)
+from aimanager.evaluation_suite.metrics import GROUPS
+
+DIAGNOSTIC_ROWS = ["CA", "CC", "CE"]
+
+
+def evaluate(human, sims):
+    """d(human, sim) for every metric row and pairing, as a long frame."""
+    rows = []
+    for run, sim in sims.items():
+        for group in GROUPS.values():
+            for name, kind in group.KINDS.items():
+                extract = getattr(group, name.lower())
+                rows.append(
+                    {
+                        "run": run,
+                        "metric": name,
+                        "kind": kind,
+                        "d": group.d(name, human, sim),
+                        "std_diff": (
+                            group.std_diff(name, sim, human)
+                            if name in DIAGNOSTIC_ROWS
+                            else None
+                        ),
+                        "n_human": len(extract(human)),
+                        "n_sim": len(extract(sim)),
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def run_cli(config, config_path):
+    if "output_dir" in config:
+        output_dir = config["output_dir"]
+    else:
+        output_dir = os.path.splitext(config_path)[0]
+
+    parquet_path = os.path.join(output_dir, "per_round.parquet")
+    if not os.path.exists(parquet_path):
+        print(
+            f"Error: {parquet_path} not found. Run the simulation with "
+            "save_per_round: true first (python -m aimanager simulate "
+            f"{config_path}).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    switch_every = config.get("switch_every", 4)
+    human = load_human(HUMAN_DATA_FILE, switch_every=switch_every)
+    sims = load_sim(parquet_path, switch_every=switch_every)
+
+    result = evaluate(human, sims)
+    out_path = os.path.join(output_dir, "metrics.csv")
+    result.to_csv(out_path, index=False)
+    print(f"{len(result)} rows ({len(sims)} pairings) -> {out_path}")

--- a/src/aimanager/evaluation_suite/metrics.py
+++ b/src/aimanager/evaluation_suite/metrics.py
@@ -1,0 +1,83 @@
+"""Metric extraction for the evaluation suite (#128).
+
+One class per metric group (contribution / switching / punishment), one
+method per metric row. Each method turns a canonical agent-round frame
+(see convert.py) into the raw material its score is computed from -- no
+differencing happens here, so human and simulation extractions can be
+inspected side by side. Two kinds of rows:
+
+- distribution: the method returns the observations whose distribution the
+  row compares (scored with EMD in a later step)
+- statistic: the method returns the row's statistic, one value per stratum
+  (scored as weighted absolute differences in a later step)
+
+Empty groups produce no rows in the canonical frame, so group-level
+extractions lose exactly the empty cell (CC) or the whole game-round where
+the difference needs both groups (CE); participant-level metrics keep the
+surviving group's rows. NaN (no-input) values drop out of every mean and
+count. See notes/evaluation_metric_defs.md for the row definitions.
+"""
+
+PARTICIPANT = ["episode_id", "participant_code"]
+GROUP_CELL = ["episode_id", "round_number", "group_id"]
+
+
+class MetricGroup:
+    """Subclasses define KINDS ({row name: 'distribution' | 'statistic'})
+    and one extraction method per row, named after the row in lowercase.
+    Every method returns a named pd.Series -- observations for
+    distributions, per-stratum values for statistics."""
+
+    KINDS = {}
+
+    def extract_all(self, df):
+        return {name: getattr(self, name.lower())(df) for name in self.KINDS}
+
+
+class ContributionMetrics(MetricGroup):
+    KINDS = {
+        "CA": "distribution",
+        "CB": "statistic",
+        "CC": "distribution",
+        "CD": "distribution",
+        "CE": "distribution",
+        "CF": "statistic",
+    }
+
+    def ca(self, df):
+        """Participant mean contributions."""
+        obs = df.groupby(PARTICIPANT)["contribution"].mean().dropna()
+        return obs.rename("CA")
+
+    def cb(self, df):
+        """Round mean contributions."""
+        stat = df.groupby("round_number")["contribution"].mean()
+        return stat.rename("CB")
+
+    def cc(self, df):
+        """Group mean contributions per (game, round)."""
+        obs = df.groupby(GROUP_CELL)["contribution"].mean().dropna()
+        return obs.rename("CC")
+
+    def cd(self, df):
+        """Raw contributions."""
+        return df["contribution"].dropna().rename("CD")
+
+    def ce(self, df):
+        """Signed group contribution differences (group 0 minus group 1)
+        per (game, round); drops game-rounds where either group is empty."""
+        means = df.groupby(GROUP_CELL)["contribution"].mean()
+        wide = means.unstack("group_id").dropna()
+        return (wide[0] - wide[1]).rename("CE")
+
+    def cf(self, df):
+        """Share of contributions at the boundaries (0 and 20) per round."""
+        valid = df.dropna(subset=["contribution"])
+        shares = valid.groupby("round_number")["contribution"].agg(
+            share_at_0=lambda c: c.eq(0).mean(),
+            share_at_20=lambda c: c.eq(20).mean(),
+        )
+        return shares.stack().rename("CF")
+
+
+GROUPS = {"C": ContributionMetrics()}

--- a/src/aimanager/evaluation_suite/metrics.py
+++ b/src/aimanager/evaluation_suite/metrics.py
@@ -18,6 +18,8 @@ surviving group's rows. NaN (no-input) values drop out of every mean and
 count. See notes/evaluation_metric_defs.md for the row definitions.
 """
 
+import pandas as pd
+
 PARTICIPANT = ["episode_id", "participant_code"]
 GROUP_CELL = ["episode_id", "round_number", "group_id"]
 
@@ -80,4 +82,32 @@ class ContributionMetrics(MetricGroup):
         return shares.stack().rename("CF")
 
 
-GROUPS = {"C": ContributionMetrics()}
+class SwitchingMetrics(MetricGroup):
+    KINDS = {
+        "SA": "statistic",
+        "SB": "statistic",
+        "SC": "distribution",
+    }
+
+    def sa(self, df):
+        """Overall switch rate over valid switching opportunities."""
+        valid = df[df["switch_valid"]]
+        rate = valid["does_switch"].mean()
+        return pd.Series({"switch_rate": rate}, name="SA")
+
+    def sb(self, df):
+        """Switch rate per switching opportunity (decision round)."""
+        valid = df[df["switch_valid"]]
+        stat = valid.groupby("round_number")["does_switch"].mean()
+        return stat.rename("SB")
+
+    def sc(self, df):
+        """Size of the larger group per (game, round), rounds 4 onward.
+        Empty-group rounds are kept: larger-group size 8 is the maximal
+        segregation observation this row exists to measure."""
+        sizes = df[df["round_number"] >= 4].groupby(GROUP_CELL).size()
+        obs = sizes.groupby(["episode_id", "round_number"]).max()
+        return obs.rename("SC")
+
+
+GROUPS = {"C": ContributionMetrics(), "S": SwitchingMetrics()}

--- a/src/aimanager/evaluation_suite/metrics.py
+++ b/src/aimanager/evaluation_suite/metrics.py
@@ -19,21 +19,66 @@ count. See notes/evaluation_metric_defs.md for the row definitions.
 """
 
 import pandas as pd
+from scipy.stats import wasserstein_distance
 
 PARTICIPANT = ["episode_id", "participant_code"]
 GROUP_CELL = ["episode_id", "round_number", "group_id"]
+
+ROUNDS = pd.RangeIndex(24, name="round_number")
+DECISION_ROUNDS = pd.Index([3, 7, 11, 15, 19], name="round_number")
+
+
+def _uniform(index):
+    return pd.Series(1.0, index=index)
 
 
 class MetricGroup:
     """Subclasses define KINDS ({row name: 'distribution' | 'statistic'})
     and one extraction method per row, named after the row in lowercase.
     Every method returns a named pd.Series -- observations for
-    distributions, per-stratum values for statistics."""
+    distributions, per-stratum values for statistics. Statistic rows also
+    define a <row>_weights method returning the number of observations
+    underlying each stratum's value."""
 
     KINDS = {}
 
     def extract_all(self, df):
         return {name: getattr(self, name.lower())(df) for name in self.KINDS}
+
+    def weights(self, name, df):
+        """Stratum weights for a statistic row. Strata fixed by the game
+        design (rounds, boundary cells, switching opportunities -- all of
+        C/S/P) carry uniform precomputed weights and ignore df; strata
+        conditioned on behaviour (the R rows, later branch) carry
+        human-frequency weights computed once on the human reference and
+        reused for every comparison (#132)."""
+        return getattr(self, f"{name.lower()}_weights")(df)
+
+    def d(self, name, df_a, df_b, weights=None):
+        """Discrepancy between two datasets on one row, callable on any
+        episode subset (#132's scoring pipeline consumes this directly).
+        Distribution rows: EMD (1-Wasserstein on the empirical samples,
+        no binning). Statistic rows: weighted mean absolute per-stratum
+        difference under the row's weight scheme (see weights()); pass
+        precomputed weights or let them default to weights(name, df_a).
+        Strata missing from either side drop out and the weights
+        renormalise over the rest."""
+        extract = getattr(self, name.lower())
+        a, b = extract(df_a), extract(df_b)
+        if self.KINDS[name] == "distribution":
+            return wasserstein_distance(a, b)
+        if weights is None:
+            weights = self.weights(name, df_a)
+        aligned = pd.concat({"a": a, "b": b, "w": weights}, axis=1).dropna()
+        return ((aligned["a"] - aligned["b"]).abs() * aligned["w"]).sum() / aligned[
+            "w"
+        ].sum()
+
+    def std_diff(self, name, df, reference_df):
+        """Signed std difference in raw units (df minus reference) -- the
+        retained diagnostic for CA/CC/CE, reported unnormalised."""
+        extract = getattr(self, name.lower())
+        return extract(df).std() - extract(reference_df).std()
 
 
 class ContributionMetrics(MetricGroup):
@@ -81,6 +126,13 @@ class ContributionMetrics(MetricGroup):
         )
         return shares.stack().rename("CF")
 
+    def cb_weights(self, df=None):
+        return _uniform(ROUNDS)
+
+    def cf_weights(self, df=None):
+        cells = pd.MultiIndex.from_product([ROUNDS, ["share_at_0", "share_at_20"]])
+        return _uniform(cells)
+
 
 class SwitchingMetrics(MetricGroup):
     KINDS = {
@@ -109,6 +161,12 @@ class SwitchingMetrics(MetricGroup):
         obs = sizes.groupby(["episode_id", "round_number"]).max()
         return obs.rename("SC")
 
+    def sa_weights(self, df=None):
+        return pd.Series({"switch_rate": 1.0})
+
+    def sb_weights(self, df=None):
+        return _uniform(DECISION_ROUNDS)
+
 
 class PunishmentMetrics(MetricGroup):
     KINDS = {
@@ -132,6 +190,11 @@ class PunishmentMetrics(MetricGroup):
         valid = df.dropna(subset=["punishment"])
         stat = valid.groupby("round_number")["punishment"].agg(lambda p: p.eq(0).mean())
         return stat.rename("PC")
+
+    def pb_weights(self, df=None):
+        return _uniform(ROUNDS)
+
+    pc_weights = pb_weights
 
 
 GROUPS = {

--- a/src/aimanager/evaluation_suite/metrics.py
+++ b/src/aimanager/evaluation_suite/metrics.py
@@ -110,4 +110,32 @@ class SwitchingMetrics(MetricGroup):
         return obs.rename("SC")
 
 
-GROUPS = {"C": ContributionMetrics(), "S": SwitchingMetrics()}
+class PunishmentMetrics(MetricGroup):
+    KINDS = {
+        "PA": "distribution",
+        "PB": "statistic",
+        "PC": "statistic",
+    }
+
+    def pa(self, df):
+        """Raw received punishments, zeros included."""
+        return df["punishment"].dropna().rename("PA")
+
+    def pb(self, df):
+        """Round mean punishments."""
+        stat = df.groupby("round_number")["punishment"].mean()
+        return stat.rename("PB")
+
+    def pc(self, df):
+        """Share of players receiving zero punishment per round (the
+        extensive margin: whether to punish, as against how much)."""
+        valid = df.dropna(subset=["punishment"])
+        stat = valid.groupby("round_number")["punishment"].agg(lambda p: p.eq(0).mean())
+        return stat.rename("PC")
+
+
+GROUPS = {
+    "C": ContributionMetrics(),
+    "S": SwitchingMetrics(),
+    "P": PunishmentMetrics(),
+}

--- a/src/aimanager/tests/test_eval_convert.py
+++ b/src/aimanager/tests/test_eval_convert.py
@@ -1,0 +1,90 @@
+"""Structure and semantics tests for the evaluation-suite conversion layer.
+
+Confirms that the human and simulation conversions produce exactly the same
+canonical structure (#128) by converting both tracked sources fresh.
+"""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from aimanager.evaluation_suite.convert import (
+    CANONICAL_COLUMNS,
+    HUMAN_DATA_FILE,
+    SIM_EXAMPLE_FILE,
+    load_human,
+    load_sim,
+)
+
+REPO = Path(__file__).resolve().parents[3]
+DECISION_ROUNDS = {3, 7, 11, 15, 19}
+
+
+@pytest.fixture(scope="module")
+def human():
+    return load_human(REPO / HUMAN_DATA_FILE)
+
+
+@pytest.fixture(scope="module")
+def sims():
+    return load_sim(REPO / SIM_EXAMPLE_FILE)
+
+
+def test_structures_match_exactly(human, sims):
+    assert list(human.columns) == CANONICAL_COLUMNS
+    for sim in sims.values():
+        assert list(sim.columns) == CANONICAL_COLUMNS
+        assert sim.dtypes.astype(str).to_dict() == human.dtypes.astype(str).to_dict()
+
+
+def test_human_dedupe_and_masking(human):
+    raw = pd.read_csv(REPO / HUMAN_DATA_FILE)
+    assert raw["episode_id"].nunique() == 100  # flip augmentation doubles
+    assert human["episode_id"].nunique() == 50
+    deduped_raw = raw[
+        raw["episode_id"] == raw.groupby("pair_id")["episode_id"].transform("min")
+    ]
+    assert (
+        human["contribution"].isna().sum()
+        == (deduped_raw["player_no_input"] != 0).sum()
+    )
+    assert (
+        human["punishment"].isna().sum() == (deduped_raw["manager_no_input"] != 0).sum()
+    )
+
+
+def test_switch_labelling(human, sims):
+    for df in [human, *sims.values()]:
+        assert set(df.loc[df["switch_mask"], "round_number"]) == DECISION_ROUNDS
+        assert (df["does_switch"] <= df["switch_mask"]).all()
+        assert (df["switch_valid"] <= df["switch_mask"]).all()
+
+        # membership changes exactly where a decision row said "switch"
+        df = df.sort_values(["episode_id", "participant_code", "round_number"])
+        by_player = df.groupby(["episode_id", "participant_code"])
+        changes = (
+            by_player["group_id"].shift(-1).ne(df["group_id"])
+            & by_player["group_id"].shift(-1).notna()
+        )
+        assert changes.equals(df["does_switch"])
+
+
+def test_human_timeouts_excluded(human):
+    assert human["switch_valid"].sum() < human["switch_mask"].sum()
+
+
+def test_sim_has_no_invalid_rows(sims):
+    for sim in sims.values():
+        assert sim["contribution"].notna().all()
+        assert sim["punishment"].notna().all()
+        assert sim["switch_valid"].equals(sim["switch_mask"])
+
+
+def test_episode_shapes(human, sims):
+    for df in [human, *sims.values()]:
+        rounds = df.groupby("episode_id")["round_number"].agg(["min", "max", "size"])
+        assert (rounds["min"] == 0).all()
+        assert (rounds["max"] == 23).all()
+        assert (rounds["size"] == 8 * 24).all()
+        assert set(df["group_id"]) <= {0, 1}

--- a/src/aimanager/tests/test_eval_evaluate.py
+++ b/src/aimanager/tests/test_eval_evaluate.py
@@ -1,0 +1,51 @@
+"""Tests for the evaluation-suite main script (#128)."""
+
+from pathlib import Path
+
+import pytest
+
+from aimanager.evaluation_suite.convert import (
+    HUMAN_DATA_FILE,
+    SIM_EXAMPLE_FILE,
+    load_human,
+    load_sim,
+)
+from aimanager.evaluation_suite.evaluate import evaluate, run_cli
+from aimanager.evaluation_suite.metrics import GROUPS
+
+REPO = Path(__file__).resolve().parents[3]
+N_ROWS = sum(len(g.KINDS) for g in GROUPS.values())
+
+
+def test_evaluate_produces_one_row_per_pairing_and_metric():
+    human = load_human(REPO / HUMAN_DATA_FILE)
+    sims = load_sim(REPO / SIM_EXAMPLE_FILE)
+    result = evaluate(human, sims)
+
+    assert len(result) == N_ROWS * len(sims)
+    assert (result["d"] >= 0).all()
+    assert result["d"].notna().all()
+    # diagnostics only on CA/CC/CE
+    assert set(result.loc[result["std_diff"].notna(), "metric"]) == {
+        "CA",
+        "CC",
+        "CE",
+    }
+
+
+def test_run_cli_fails_clearly_without_parquet(tmp_path, capsys):
+    config = {"output_dir": str(tmp_path / "nowhere")}
+    with pytest.raises(SystemExit):
+        run_cli(config, "some_config.yml")
+    assert "save_per_round" in capsys.readouterr().err
+
+
+def test_run_cli_writes_metrics_csv(tmp_path):
+    # point a minimal config at the real per_round.parquet via a symlink
+    output_dir = tmp_path / "run"
+    output_dir.mkdir()
+    (output_dir / "per_round.parquet").symlink_to(REPO / SIM_EXAMPLE_FILE)
+    run_cli({"output_dir": str(output_dir)}, "some_config.yml")
+    out = output_dir / "metrics.csv"
+    assert out.exists()
+    assert sum(1 for _ in open(out)) == 3 * N_ROWS + 1  # 3 pairings + header

--- a/src/aimanager/tests/test_eval_metrics.py
+++ b/src/aimanager/tests/test_eval_metrics.py
@@ -218,3 +218,60 @@ def test_all_metrics_extract_from_sim():
         for name, e in group.extract_all(sim).items():
             assert len(e) > 0, name
             assert not e.isna().any(), name
+
+
+def test_d_self_comparison_is_zero(human):
+    half = human[human["episode_id"] < human["episode_id"].median()]
+    for group in [C, S, P]:
+        for name in group.KINDS:
+            assert group.d(name, human, human) == pytest.approx(0), name
+            # callable on episode subsets, still zero against itself
+            assert group.d(name, half, half) == pytest.approx(0), name
+
+
+def test_d_distribution_is_emd(frame):
+    shifted = frame.assign(contribution=frame["contribution"] + 2)
+    assert C.d("CD", frame, shifted) == pytest.approx(2.0)
+
+
+def test_d_statistic_uniform_over_present_strata(frame):
+    # +2 only in round 0: per-round |diff| = [2, 0, 0], uniform weights
+    # renormalise over the 3 rounds present (of the 24 fixed strata)
+    bumped = frame.copy()
+    bumped.loc[bumped["round_number"] == 0, "contribution"] += 2
+    assert C.d("CB", frame, bumped) == pytest.approx(2 / 3)
+
+
+def test_d_statistic_renormalises_over_missing_strata(frame):
+    # comparison side lacks round 2: weights renormalise over rounds 0-1
+    bumped = frame.copy()
+    bumped.loc[bumped["round_number"] == 0, "contribution"] += 2
+    bumped = bumped[bumped["round_number"] < 2]
+    assert C.d("CB", frame, bumped) == pytest.approx(1.0)
+
+
+def test_d_accepts_precomputed_weights(frame):
+    # a custom weight vector overrides the row's default scheme
+    bumped = frame.copy()
+    bumped.loc[bumped["round_number"] == 0, "contribution"] += 2
+    w = pd.Series({0: 1.0, 1: 3.0, 2: 4.0})
+    assert C.d("CB", frame, bumped, weights=w) == pytest.approx(2 / 8)
+
+
+def test_uniform_precomputed_weights():
+    # design-fixed strata: full index regardless of the data passed
+    assert C.weights("CB", None).tolist() == [1.0] * 24
+    cf = C.weights("CF", None)
+    assert len(cf) == 48
+    assert cf.loc[(23, "share_at_20")] == 1.0
+    assert S.weights("SA", None).loc["switch_rate"] == 1.0
+    assert list(S.weights("SB", None).index) == [3, 7, 11, 15, 19]
+    assert P.weights("PB", None).equals(P.weights("PC", None))
+
+
+def test_std_diff_is_signed(frame):
+    shifted = frame.assign(contribution=frame["contribution"] + 2)
+    doubled = frame.assign(contribution=frame["contribution"] * 2)
+    assert C.std_diff("CD", shifted, frame) == pytest.approx(0)  # shift: same std
+    raw_std = pd.Series([0, 10, 20, 20, 10, 0, 20, 5, 10, 15, 20], dtype=float).std()
+    assert C.std_diff("CD", doubled, frame) == pytest.approx(raw_std)

--- a/src/aimanager/tests/test_eval_metrics.py
+++ b/src/aimanager/tests/test_eval_metrics.py
@@ -1,0 +1,117 @@
+"""Extraction tests for the evaluation-suite metrics (#128).
+
+Each metric is pinned twice: exact values on a small hand-computed frame
+(covering NaN masking and the empty-group cases), and regression pins on
+the converted human reference data.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from aimanager.evaluation_suite.convert import (
+    HUMAN_DATA_FILE,
+    SIM_EXAMPLE_FILE,
+    load_human,
+    load_sim,
+)
+from aimanager.evaluation_suite.metrics import ContributionMetrics
+
+REPO = Path(__file__).resolve().parents[3]
+
+C = ContributionMetrics()
+
+
+@pytest.fixture(scope="module")
+def human():
+    return load_human(REPO / HUMAN_DATA_FILE)
+
+
+@pytest.fixture()
+def frame():
+    """One episode, four participants. Round 1: participant a gave no
+    input. Round 2: everyone congregates in group 0 (group 1 empty)."""
+    rows = [
+        (0, "a", 0, 0, 0.0),
+        (0, "b", 0, 0, 10.0),
+        (0, "c", 0, 1, 20.0),
+        (0, "d", 0, 1, 20.0),
+        (0, "a", 1, 0, np.nan),
+        (0, "b", 1, 0, 10.0),
+        (0, "c", 1, 1, 0.0),
+        (0, "d", 1, 1, 20.0),
+        (0, "a", 2, 0, 5.0),
+        (0, "b", 2, 0, 10.0),
+        (0, "c", 2, 0, 15.0),
+        (0, "d", 2, 0, 20.0),
+    ]
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "episode_id",
+            "participant_code",
+            "round_number",
+            "group_id",
+            "contribution",
+        ],
+    )
+
+
+def test_ca_participant_means(frame):
+    obs = C.ca(frame)
+    assert obs.tolist() == pytest.approx([2.5, 10.0, 35 / 3, 20.0])
+
+
+def test_cb_round_means(frame):
+    stat = C.cb(frame)
+    assert stat.tolist() == pytest.approx([12.5, 10.0, 12.5])
+
+
+def test_cc_group_means_keep_surviving_group(frame):
+    obs = C.cc(frame)
+    assert obs.tolist() == pytest.approx([5.0, 20.0, 10.0, 10.0, 12.5])
+    assert (0, 2, 1) not in obs.index  # empty group: no observation
+
+
+def test_cd_raw_contributions(frame):
+    obs = C.cd(frame)
+    assert len(obs) == 11  # the NaN row drops
+
+
+def test_ce_drops_empty_group_rounds(frame):
+    obs = C.ce(frame)
+    assert obs.tolist() == pytest.approx([-15.0, 0.0])  # rounds 0 and 1
+    assert list(obs.index.get_level_values("round_number")) == [0, 1]
+
+
+def test_cf_boundary_shares(frame):
+    stat = C.cf(frame)
+    assert stat.loc[(0, "share_at_0")] == pytest.approx(0.25)
+    assert stat.loc[(0, "share_at_20")] == pytest.approx(0.5)
+    assert stat.loc[(1, "share_at_0")] == pytest.approx(1 / 3)  # of 3 valid
+    assert stat.loc[(2, "share_at_20")] == pytest.approx(0.25)
+
+
+def test_human_reference_pins(human):
+    extractions = C.extract_all(human)
+    assert {k: len(v) for k, v in extractions.items()} == {
+        "CA": 400,  # 50 episodes x 8 participants
+        "CB": 24,
+        "CC": 2239,  # 2256 cells - 144 empty-group - 17 all-no-input
+        "CD": 9320,  # 9600 rows - 280 no-input
+        "CE": 1039,  # 1200 game-rounds - 144 empty-group - 17 all-no-input
+        "CF": 48,
+    }
+    assert extractions["CB"].loc[0] == pytest.approx(9.067358, abs=1e-5)
+    assert extractions["CE"].mean() == pytest.approx(-0.383599, abs=1e-5)
+    assert extractions["CF"].loc[(0, "share_at_0")] == pytest.approx(0.051813, abs=1e-5)
+
+
+def test_all_metrics_extract_from_sim():
+    sims = load_sim(REPO / SIM_EXAMPLE_FILE)
+    sim = sims[sorted(sims)[0]]
+    for name, e in C.extract_all(sim).items():
+        assert len(e) > 0, name
+        assert not e.isna().any(), name

--- a/src/aimanager/tests/test_eval_metrics.py
+++ b/src/aimanager/tests/test_eval_metrics.py
@@ -17,12 +17,17 @@ from aimanager.evaluation_suite.convert import (
     load_human,
     load_sim,
 )
-from aimanager.evaluation_suite.metrics import ContributionMetrics, SwitchingMetrics
+from aimanager.evaluation_suite.metrics import (
+    ContributionMetrics,
+    PunishmentMetrics,
+    SwitchingMetrics,
+)
 
 REPO = Path(__file__).resolve().parents[3]
 
 C = ContributionMetrics()
 S = SwitchingMetrics()
+P = PunishmentMetrics()
 
 
 @pytest.fixture(scope="module")
@@ -33,20 +38,21 @@ def human():
 @pytest.fixture()
 def frame():
     """One episode, four participants. Round 1: participant a gave no
-    input. Round 2: everyone congregates in group 0 (group 1 empty)."""
+    input (and their manager no punishment input). Round 2: everyone
+    congregates in group 0 (group 1 empty)."""
     rows = [
-        (0, "a", 0, 0, 0.0),
-        (0, "b", 0, 0, 10.0),
-        (0, "c", 0, 1, 20.0),
-        (0, "d", 0, 1, 20.0),
-        (0, "a", 1, 0, np.nan),
-        (0, "b", 1, 0, 10.0),
-        (0, "c", 1, 1, 0.0),
-        (0, "d", 1, 1, 20.0),
-        (0, "a", 2, 0, 5.0),
-        (0, "b", 2, 0, 10.0),
-        (0, "c", 2, 0, 15.0),
-        (0, "d", 2, 0, 20.0),
+        (0, "a", 0, 0, 0.0, 0.0),
+        (0, "b", 0, 0, 10.0, 5.0),
+        (0, "c", 0, 1, 20.0, 0.0),
+        (0, "d", 0, 1, 20.0, 10.0),
+        (0, "a", 1, 0, np.nan, np.nan),
+        (0, "b", 1, 0, 10.0, 0.0),
+        (0, "c", 1, 1, 0.0, 30.0),
+        (0, "d", 1, 1, 20.0, 0.0),
+        (0, "a", 2, 0, 5.0, 0.0),
+        (0, "b", 2, 0, 10.0, 0.0),
+        (0, "c", 2, 0, 15.0, 0.0),
+        (0, "d", 2, 0, 20.0, 0.0),
     ]
     return pd.DataFrame(
         rows,
@@ -56,6 +62,7 @@ def frame():
             "round_number",
             "group_id",
             "contribution",
+            "punishment",
         ],
     )
 
@@ -151,6 +158,22 @@ def test_sc_larger_group_keeps_empty_rounds(switch_frame):
     assert (0, 3) not in obs.index  # rounds < 4 excluded
 
 
+def test_pa_raw_punishments(frame):
+    obs = P.pa(frame)
+    assert len(obs) == 11  # the manager-no-input NaN drops
+    assert obs.sum() == pytest.approx(45.0)
+
+
+def test_pb_round_means(frame):
+    stat = P.pb(frame)
+    assert stat.tolist() == pytest.approx([3.75, 10.0, 0.0])  # r1: of 3 valid
+
+
+def test_pc_zero_shares(frame):
+    stat = P.pc(frame)
+    assert stat.tolist() == pytest.approx([0.5, 2 / 3, 1.0])
+
+
 def test_human_reference_pins(human):
     extractions = C.extract_all(human)
     assert {k: len(v) for k, v in extractions.items()} == {
@@ -178,10 +201,20 @@ def test_human_switching_pins(human):
     assert sc.mean() == pytest.approx(6.088, abs=1e-5)
 
 
+def test_human_punishment_pins(human):
+    extractions = P.extract_all(human)
+    pa = extractions["PA"]
+    assert len(pa) == 9193  # 9600 rows - 407 manager-no-input
+    assert pa.mean() == pytest.approx(1.791254, abs=1e-5)
+    assert pa.eq(0).mean() == pytest.approx(0.694224, abs=1e-5)
+    assert extractions["PB"].loc[0] == pytest.approx(4.090659, abs=1e-5)
+    assert extractions["PC"].loc[0] == pytest.approx(0.445055, abs=1e-5)
+
+
 def test_all_metrics_extract_from_sim():
     sims = load_sim(REPO / SIM_EXAMPLE_FILE)
     sim = sims[sorted(sims)[0]]
-    for group in [C, S]:
+    for group in [C, S, P]:
         for name, e in group.extract_all(sim).items():
             assert len(e) > 0, name
             assert not e.isna().any(), name

--- a/src/aimanager/tests/test_eval_metrics.py
+++ b/src/aimanager/tests/test_eval_metrics.py
@@ -17,11 +17,12 @@ from aimanager.evaluation_suite.convert import (
     load_human,
     load_sim,
 )
-from aimanager.evaluation_suite.metrics import ContributionMetrics
+from aimanager.evaluation_suite.metrics import ContributionMetrics, SwitchingMetrics
 
 REPO = Path(__file__).resolve().parents[3]
 
 C = ContributionMetrics()
+S = SwitchingMetrics()
 
 
 @pytest.fixture(scope="module")
@@ -94,6 +95,62 @@ def test_cf_boundary_shares(frame):
     assert stat.loc[(2, "share_at_20")] == pytest.approx(0.25)
 
 
+@pytest.fixture()
+def switch_frame():
+    """One episode, four participants. Decision rounds 3 and 7: a switches
+    at 3 (c's choice timed out), b switches at 7. Round 5: everyone in
+    group 1 (group 0 empty)."""
+    rows = [
+        (0, "a", 3, 0, True, True, True),
+        (0, "b", 3, 0, False, True, True),
+        (0, "c", 3, 1, False, True, False),
+        (0, "d", 3, 1, False, True, True),
+        (0, "a", 4, 1, False, False, False),
+        (0, "b", 4, 0, False, False, False),
+        (0, "c", 4, 1, False, False, False),
+        (0, "d", 4, 1, False, False, False),
+        (0, "a", 5, 1, False, False, False),
+        (0, "b", 5, 1, False, False, False),
+        (0, "c", 5, 1, False, False, False),
+        (0, "d", 5, 1, False, False, False),
+        (0, "a", 7, 1, False, True, True),
+        (0, "b", 7, 1, True, True, True),
+        (0, "c", 7, 1, False, True, True),
+        (0, "d", 7, 1, False, True, True),
+    ]
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "episode_id",
+            "participant_code",
+            "round_number",
+            "group_id",
+            "does_switch",
+            "switch_mask",
+            "switch_valid",
+        ],
+    )
+
+
+def test_sa_overall_switch_rate(switch_frame):
+    # 7 valid opportunities (c's round-3 timeout drops), 2 switches
+    assert S.sa(switch_frame).loc["switch_rate"] == pytest.approx(2 / 7)
+
+
+def test_sb_rate_per_opportunity(switch_frame):
+    stat = S.sb(switch_frame)
+    assert stat.loc[3] == pytest.approx(1 / 3)  # a of {a, b, d}
+    assert stat.loc[7] == pytest.approx(1 / 4)
+    assert list(stat.index) == [3, 7]
+
+
+def test_sc_larger_group_keeps_empty_rounds(switch_frame):
+    obs = S.sc(switch_frame)
+    assert obs.loc[(0, 4)] == 3  # groups split 1-3
+    assert obs.loc[(0, 5)] == 4  # group 0 empty: kept as max segregation
+    assert (0, 3) not in obs.index  # rounds < 4 excluded
+
+
 def test_human_reference_pins(human):
     extractions = C.extract_all(human)
     assert {k: len(v) for k, v in extractions.items()} == {
@@ -109,9 +166,22 @@ def test_human_reference_pins(human):
     assert extractions["CF"].loc[(0, "share_at_0")] == pytest.approx(0.051813, abs=1e-5)
 
 
+def test_human_switching_pins(human):
+    extractions = S.extract_all(human)
+    assert extractions["SA"].loc["switch_rate"] == pytest.approx(0.296668, abs=1e-5)
+    assert list(extractions["SB"].index) == [3, 7, 11, 15, 19]
+    assert extractions["SB"].loc[3] == pytest.approx(0.44186, abs=1e-5)
+    sc = extractions["SC"]
+    assert len(sc) == 1000  # 50 episodes x rounds 4..23
+    # the 144 empty-group rounds appear as larger-group size 8
+    assert sc.value_counts().loc[8] == 144
+    assert sc.mean() == pytest.approx(6.088, abs=1e-5)
+
+
 def test_all_metrics_extract_from_sim():
     sims = load_sim(REPO / SIM_EXAMPLE_FILE)
     sim = sims[sorted(sims)[0]]
-    for name, e in C.extract_all(sim).items():
-        assert len(e) > 0, name
-        assert not e.isna().any(), name
+    for group in [C, S]:
+        for name, e in group.extract_all(sim).items():
+            assert len(e) > 0, name
+            assert not e.isna().any(), name


### PR DESCRIPTION
Implements the C/S/P scope of #128 — the evaluation suite that compares simulation outputs against the human experiment. The R (response) metrics follow on a separate branch. All design decisions are recorded in the [resolved-ambiguities comment](https://github.com/center-for-humans-and-machines/algorithmic-institutions/issues/128#issuecomment-5103143179); the definitions live in `notes/evaluation_metric_defs.md`.

## What's here (one commit per step, reviewable in order)

1. **Metric definitions doc** (`notes/evaluation_metric_defs.md`) — one plain sentence per metric (all 19 rows incl. R), canonical score and empty-group handling per row, shared conventions in the header.
2. **Conversion layer** (`evaluation_suite/convert.py`) — `load_human` (flip-augmentation dedup, no-input → NaN, `does_switch`/`switch_valid` at decision rounds mirroring `generic/data.py`) and `load_sim` (one canonical frame per pairing). Identical structure asserted by tests.
3. **Metric framework + C extraction** (`evaluation_suite/metrics.py`) — one class per group, one method per row, extraction only (CA–CF).
4. **S extraction** — SA, SB (`switch_valid` denominators), SC (larger-group size, rounds ≥ 4, empty-group rounds kept as the maximal-segregation observation).
5. **P extraction** — PA, PB, PC.
6. **Discrepancy interface** — `d(name, df_a, df_b)` per row: unbinned 1-Wasserstein for distribution rows, weighted mean absolute per-stratum difference for statistic rows (uniform precomputed weights for the design-fixed C/S/P strata; human-frequency weights reserved for the behaviour-conditioned R bins, per #132). Callable on arbitrary episode subsets so the #132 scoring pipeline consumes the metric objects directly. Plus `std_diff`, the retained signed CA/CC/CE dispersion diagnostic.
7. **Main script + CLI** — `python -m aimanager evaluate <sim config>`: reads the finished simulation's `per_round.parquet`, writes `metrics.csv` (pairing × metric: `d`, diagnostic, observation counts) into `output_dir`.

## Quick-look results (raw units, unnormalised — #132 normalises)

`python -m aimanager evaluate configs/simulation/manager_testing/22_2g8a_linear_self_ridge_contr.yml` (committed as the first run output):

| metric | kind | lin_gaussian | lin_multinomial | lin_ridge |
|---|---|---|---|---|
| CA | distribution | 2.36 | 2.21 | 2.39 |
| CB | statistic | 1.15 | 0.51 | 0.92 |
| CC | distribution | 1.70 | 1.65 | 1.81 |
| CD | distribution | 1.62 | 1.38 | 1.60 |
| CE | distribution | 1.61 | 1.95 | 1.81 |
| CF | statistic | 0.073 | 0.079 | 0.080 |
| SA | statistic | 0.026 | 0.011 | 0.024 |
| SB | statistic | 0.029 | 0.037 | 0.037 |
| SC | distribution | 0.49 | 0.66 | 0.75 |
| PA | distribution | 1.97 | **0.05** | 2.30 |
| PB | statistic | 1.86 | **0.32** | 1.64 |
| PC | statistic | 0.39 | **0.03** | 0.41 |

The P rows cleanly separate the punishment managers — lin_multinomial is near-human, ridge/gaussian an order of magnitude off (they cannot concentrate mass on punishment 0) — consistent with #131's marginals. The CA/CC/CE signed std diagnostics are uniformly ≈ −2: every sim is under-dispersed at the participant, group and group-gap level. SC shows all sims under-segregate (humans fully congregate in 14.4% of game-rounds, sims 4–6%).

## Testing

- [x] 32 evaluation tests pass locally (the suite is pure pandas — no torch imports); black + flake8 clean
- [ ] Full suite on Raven via `scripts/remote_test.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
