### PR TITLE
Implement the R (response) evaluation metrics (#134)

### DIFF
--- a/notes/evaluation_metric_defs.md
+++ b/notes/evaluation_metric_defs.md
@@ -115,9 +115,13 @@ Canonical: abs Δ per round, averaged over the 24 rounds. Empty groups: not affe
 A response is conditioned on the stimulus it reacts to: these check whether the
 models have the right mechanisms, not just the right states. Contribution change
 means next round's contribution minus this round's, with the stimulus taken this
-round. The R rows can have empty strata (a sim that never punishes or never
-switches produces no observations in some bins); how to handle that is decided
-on the R branch.
+round; it requires a valid contribution in both rounds.
+
+The R rows could in principle have empty strata (a sim that never punishes
+hard or never switches produces no observations in some bins). We assume this
+does not happen: the discrepancy raises an error when an expected stratum is
+empty on either side, naming the row and the missing strata. If a real
+candidate model ever triggers it, a policy gets designed then (issue #134).
 
 **RCA -- contribution change by round type:** how contributions change after four
 kinds of round: no switch was allowed, the player switched, the player chose to
@@ -126,7 +130,10 @@ Canonical: EMD per round type, averaged over the 4 types.
 
 **RCB -- reaction to punishment:** the average contribution change of punished
 non-full contributors, split by punishment rate bins (0, 0.25], (0.25, 0.5],
-(0.5, 1], > 1; how strongly people respond to being punished.
+(0.5, 1], > 1; how strongly people respond to being punished. Punishment rate
+= punishment / (20 − contribution), punishment per point of shortfall: "> 1"
+means punished more than the entire shortfall, and the rate is undefined at
+contribution 20 -- exactly the ceiling case RCC exists for.
 Canonical: abs Δ per bin, averaged over the 4 bins.
 
 **RCC -- reaction at the ceiling:** among full contributors (gave 20), the average

--- a/plots/simulation/22_2g8a_linear_self_ridge_contr/metrics.csv
+++ b/plots/simulation/22_2g8a_linear_self_ridge_contr/metrics.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bc13be6994de9d88ffc3b4545e3b0dfabb22f66fa75c944ebae296ef884ad18f
-size 3452
+oid sha256:6e3586747e59b6350b92927683845f5e919a4aca0fbddb8024618739d1f1094a
+size 5447

--- a/src/aimanager/evaluation_suite/metrics.py
+++ b/src/aimanager/evaluation_suite/metrics.py
@@ -30,6 +30,9 @@ GROUP_CELL = ["episode_id", "round_number", "group_id"]
 ROUNDS = pd.RangeIndex(24, name="round_number")
 DECISION_ROUNDS = pd.Index([3, 7, 11, 15, 19], name="round_number")
 
+RCB_EDGES = [0.0, 0.25, 0.5, 1.0, float("inf")]
+RCB_LABELS = ["(0,0.25]", "(0.25,0.5]", "(0.5,1]", ">1"]
+
 
 def _uniform(index):
     return pd.Series(1.0, index=index)
@@ -52,9 +55,9 @@ class MetricGroup:
         """Stratum weights for a statistic row. Strata fixed by the game
         design (rounds, boundary cells, switching opportunities -- all of
         C/S/P) carry uniform precomputed weights and ignore df; strata
-        conditioned on behaviour (the R rows, later branch) carry
-        human-frequency weights computed once on the human reference and
-        reused for every comparison (#132)."""
+        conditioned on behaviour (the R rows) carry human-frequency
+        weights computed once on the human reference and reused for
+        every comparison (#132)."""
         return getattr(self, f"{name.lower()}_weights")(df)
 
     def d(self, name, df_a, df_b, weights=None):
@@ -234,6 +237,8 @@ class ResponseMetrics(MetricGroup):
 
     KINDS = {
         "RCA": "stratified_distribution",
+        "RCB": "statistic",
+        "RCC": "statistic",
     }
 
     def rca(self, df):
@@ -246,6 +251,45 @@ class ResponseMetrics(MetricGroup):
     def rca_weights(self, df):
         """Human frequency of each round type over dc-valid rows."""
         return self.rca(df).groupby(level=0).size()
+
+    def rcb(self, df):
+        """Mean contribution change of punished non-full contributors per
+        punishment-rate bin; rate = punishment / (20 - contribution),
+        punishment per point of shortfall."""
+        pop = self._rcb_population(df)
+        stat = pop.groupby("rate_bin", observed=False)["dc"].mean()
+        stat.index = stat.index.astype(str)
+        return stat.rename("RCB")
+
+    def rcb_weights(self, df):
+        """Human frequency of each punishment-rate bin."""
+        w = self._rcb_population(df).groupby("rate_bin", observed=False).size()
+        w.index = w.index.astype(str)
+        return w
+
+    def rcc(self, df):
+        """Contribution change of full contributors, punished minus
+        unpunished -- reaction at the ceiling, where RCB's rate is
+        undefined."""
+        d = self._with_dc(df)
+        full = d[(d["contribution"] == 20) & d["dc"].notna() & d["punishment"].notna()]
+        contrast = (
+            full.loc[full["punishment"] > 0, "dc"].mean()
+            - full.loc[full["punishment"] == 0, "dc"].mean()
+        )
+        return pd.Series({"contrast": contrast}, name="RCC")
+
+    def rcc_weights(self, df=None):
+        return pd.Series({"contrast": 1.0})
+
+    def _rcb_population(self, df):
+        d = self._with_dc(df)
+        pop = d[
+            (d["punishment"] > 0) & (d["contribution"] < 20) & d["dc"].notna()
+        ].copy()
+        rate = pop["punishment"] / (20 - pop["contribution"])
+        pop["rate_bin"] = pd.cut(rate, RCB_EDGES, labels=RCB_LABELS)
+        return pop
 
     def _with_dc(self, df):
         df = df.sort_values(PARTICIPANT + ["round_number"]).copy()

--- a/src/aimanager/evaluation_suite/metrics.py
+++ b/src/aimanager/evaluation_suite/metrics.py
@@ -7,9 +7,12 @@ differencing happens here, so human and simulation extractions can be
 inspected side by side. Two kinds of rows:
 
 - distribution: the method returns the observations whose distribution the
-  row compares (scored with EMD in a later step)
+  row compares (scored with EMD)
 - statistic: the method returns the row's statistic, one value per stratum
-  (scored as weighted absolute differences in a later step)
+  (scored as weighted absolute differences)
+- stratified_distribution: the method returns observations with the stratum
+  as the index's first level (scored as the weighted mean of per-stratum
+  EMDs)
 
 Empty groups produce no rows in the canonical frame, so group-level
 extractions lose exactly the empty cell (CC) or the whole game-round where
@@ -66,10 +69,29 @@ class MetricGroup:
         candidate model ever triggers this (#134)."""
         extract = getattr(self, name.lower())
         a, b = extract(df_a), extract(df_b)
-        if self.KINDS[name] == "distribution":
+        kind = self.KINDS[name]
+        if kind == "distribution":
             return wasserstein_distance(a, b)
         if weights is None:
             weights = self.weights(name, df_a)
+        if kind == "stratified_distribution":
+            a_strata = dict(iter(a.groupby(level=0)))
+            b_strata = dict(iter(b.groupby(level=0)))
+            missing = [
+                s for s in weights.index if s not in a_strata or s not in b_strata
+            ]
+            if missing:
+                raise ValueError(
+                    f"{name}: empty strata {missing} -- "
+                    "no empty-stratum policy exists, see #134"
+                )
+            emd = pd.Series(
+                {
+                    s: wasserstein_distance(a_strata[s], b_strata[s])
+                    for s in weights.index
+                }
+            )
+            return (emd * weights).sum() / weights.sum()
         aligned = pd.concat({"a": a, "b": b, "w": weights}, axis=1)
         empty = aligned["a"].isna() | aligned["b"].isna()
         if empty.any():
@@ -210,7 +232,20 @@ class ResponseMetrics(MetricGroup):
     derivations. Contribution change dc = c_{t+1} - c_t sits at the
     stimulus round t and is NaN unless both contributions are valid."""
 
-    KINDS = {}
+    KINDS = {
+        "RCA": "stratified_distribution",
+    }
+
+    def rca(self, df):
+        """Contribution change by round type: how contributions move after
+        the four kinds of round."""
+        labelled = self._round_types(self._with_dc(df))
+        valid = labelled[labelled["dc"].notna() & labelled["round_type"].notna()]
+        return valid.set_index("round_type")["dc"].rename("RCA")
+
+    def rca_weights(self, df):
+        """Human frequency of each round type over dc-valid rows."""
+        return self.rca(df).groupby(level=0).size()
 
     def _with_dc(self, df):
         df = df.sort_values(PARTICIPANT + ["round_number"]).copy()

--- a/src/aimanager/evaluation_suite/metrics.py
+++ b/src/aimanager/evaluation_suite/metrics.py
@@ -36,6 +36,12 @@ RCB_LABELS = ["(0,0.25]", "(0.25,0.5]", "(0.5,1]", ">1"]
 RSA_EDGES = [0.0, 3.0, 15.0, float("inf")]
 RSA_LABELS = ["1-3", "4-15", "16+"]
 
+RPA_EDGES = [-1.0, 0.0, 5.0, 10.0, 15.0, 19.0, 20.0]
+RPA_LABELS = ["{0}", "1-5", "6-10", "11-15", "16-19", "{20}"]
+
+RPB_EDGES = [0.0, 3.0, 5.0, 8.0]
+RPB_LABELS = ["1-3", "4-5", "6-8"]
+
 
 def _uniform(index):
     return pd.Series(1.0, index=index)
@@ -244,6 +250,8 @@ class ResponseMetrics(MetricGroup):
         "RCC": "statistic",
         "RCD": "statistic",
         "RSA": "statistic",
+        "RPA": "stratified_distribution",
+        "RPB": "stratified_distribution",
     }
 
     def rca(self, df):
@@ -313,6 +321,32 @@ class ResponseMetrics(MetricGroup):
         w = self._rsa_population(df).groupby("punishment_bin", observed=False).size()
         w.index = w.index.astype(str)
         return w
+
+    def rpa(self, df):
+        """Punishment distribution per contribution bin -- the manager's
+        policy: how punishment depends on what the player contributed."""
+        valid = df.dropna(subset=["punishment", "contribution"])
+        bins = pd.cut(valid["contribution"], RPA_EDGES, labels=RPA_LABELS)
+        return valid.set_index(bins.astype(str))["punishment"].rename("RPA")
+
+    def rpa_weights(self, df):
+        """Human frequency of each contribution bin."""
+        return self.rpa(df).groupby(level=0).size()
+
+    def rpb(self, df):
+        """Punishment distribution per group-size bin, rounds 4 onward;
+        empty groups drop out by construction (no rows)."""
+        late = df[df["round_number"] >= 4].copy()
+        late["group_size"] = late.groupby(GROUP_CELL)["participant_code"].transform(
+            "size"
+        )
+        valid = late.dropna(subset=["punishment"])
+        bins = pd.cut(valid["group_size"], RPB_EDGES, labels=RPB_LABELS)
+        return valid.set_index(bins.astype(str))["punishment"].rename("RPB")
+
+    def rpb_weights(self, df):
+        """Human frequency of each group-size bin."""
+        return self.rpb(df).groupby(level=0).size()
 
     def _rsa_population(self, df):
         pop = df[df["switch_valid"] & (df["punishment"] > 0)].copy()

--- a/src/aimanager/evaluation_suite/metrics.py
+++ b/src/aimanager/evaluation_suite/metrics.py
@@ -61,15 +61,22 @@ class MetricGroup:
         no binning). Statistic rows: weighted mean absolute per-stratum
         difference under the row's weight scheme (see weights()); pass
         precomputed weights or let them default to weights(name, df_a).
-        Strata missing from either side drop out and the weights
-        renormalise over the rest."""
+        Every weighted stratum must be present on both sides -- an empty
+        stratum raises, and a policy only gets designed if a real
+        candidate model ever triggers this (#134)."""
         extract = getattr(self, name.lower())
         a, b = extract(df_a), extract(df_b)
         if self.KINDS[name] == "distribution":
             return wasserstein_distance(a, b)
         if weights is None:
             weights = self.weights(name, df_a)
-        aligned = pd.concat({"a": a, "b": b, "w": weights}, axis=1).dropna()
+        aligned = pd.concat({"a": a, "b": b, "w": weights}, axis=1)
+        empty = aligned["a"].isna() | aligned["b"].isna()
+        if empty.any():
+            raise ValueError(
+                f"{name}: empty strata {aligned.index[empty].tolist()} -- "
+                "no empty-stratum policy exists, see #134"
+            )
         return ((aligned["a"] - aligned["b"]).abs() * aligned["w"]).sum() / aligned[
             "w"
         ].sum()

--- a/src/aimanager/evaluation_suite/metrics.py
+++ b/src/aimanager/evaluation_suite/metrics.py
@@ -1,7 +1,7 @@
-"""Metric extraction for the evaluation suite (#128).
+"""Metric extraction for the evaluation suite (#128, #134).
 
-One class per metric group (contribution / switching / punishment), one
-method per metric row. Each method turns a canonical agent-round frame
+One class per metric group (contribution / switching / punishment /
+response), one method per metric row. Each method turns a canonical agent-round frame
 (see convert.py) into the raw material its score is computed from -- no
 differencing happens here, so human and simulation extractions can be
 inspected side by side. Two kinds of rows:
@@ -427,4 +427,5 @@ GROUPS = {
     "C": ContributionMetrics(),
     "S": SwitchingMetrics(),
     "P": PunishmentMetrics(),
+    "R": ResponseMetrics(),
 }

--- a/src/aimanager/evaluation_suite/metrics.py
+++ b/src/aimanager/evaluation_suite/metrics.py
@@ -33,6 +33,9 @@ DECISION_ROUNDS = pd.Index([3, 7, 11, 15, 19], name="round_number")
 RCB_EDGES = [0.0, 0.25, 0.5, 1.0, float("inf")]
 RCB_LABELS = ["(0,0.25]", "(0.25,0.5]", "(0.5,1]", ">1"]
 
+RSA_EDGES = [0.0, 3.0, 15.0, float("inf")]
+RSA_LABELS = ["1-3", "4-15", "16+"]
+
 
 def _uniform(index):
     return pd.Series(1.0, index=index)
@@ -240,6 +243,7 @@ class ResponseMetrics(MetricGroup):
         "RCB": "statistic",
         "RCC": "statistic",
         "RCD": "statistic",
+        "RSA": "statistic",
     }
 
     def rca(self, df):
@@ -294,6 +298,26 @@ class ResponseMetrics(MetricGroup):
 
     def rcd_weights(self, df=None):
         return pd.Series({"pull": 1.0})
+
+    def rsa(self, df):
+        """Switch share at valid opportunities per received-punishment
+        bin, over punished contributors -- who leaves after being
+        punished, not how many."""
+        pop = self._rsa_population(df)
+        stat = pop.groupby("punishment_bin", observed=False)["does_switch"].mean()
+        stat.index = stat.index.astype(str)
+        return stat.rename("RSA")
+
+    def rsa_weights(self, df):
+        """Human frequency of each punishment bin."""
+        w = self._rsa_population(df).groupby("punishment_bin", observed=False).size()
+        w.index = w.index.astype(str)
+        return w
+
+    def _rsa_population(self, df):
+        pop = df[df["switch_valid"] & (df["punishment"] > 0)].copy()
+        pop["punishment_bin"] = pd.cut(pop["punishment"], RSA_EDGES, labels=RSA_LABELS)
+        return pop
 
     def _rcb_population(self, df):
         d = self._with_dc(df)

--- a/src/aimanager/evaluation_suite/metrics.py
+++ b/src/aimanager/evaluation_suite/metrics.py
@@ -239,6 +239,7 @@ class ResponseMetrics(MetricGroup):
         "RCA": "stratified_distribution",
         "RCB": "statistic",
         "RCC": "statistic",
+        "RCD": "statistic",
     }
 
     def rca(self, df):
@@ -281,6 +282,18 @@ class ResponseMetrics(MetricGroup):
 
     def rcc_weights(self, df=None):
         return pd.Series({"contrast": 1.0})
+
+    def rcd(self, df):
+        """Switching pull: the OLS slope of dc on the gap to the receiving
+        group over switch events (C_{n+1} - C_n ~ Chat - C_n) -- how far
+        switchers move toward their new group's level."""
+        events = self._switch_events(df).dropna(subset=["dc", "receiving_mean"])
+        gap = events["receiving_mean"] - events["contribution"]
+        slope = gap.cov(events["dc"]) / gap.var()
+        return pd.Series({"pull": slope}, name="RCD")
+
+    def rcd_weights(self, df=None):
+        return pd.Series({"pull": 1.0})
 
     def _rcb_population(self, df):
         d = self._with_dc(df)

--- a/src/aimanager/evaluation_suite/metrics.py
+++ b/src/aimanager/evaluation_suite/metrics.py
@@ -204,6 +204,75 @@ class PunishmentMetrics(MetricGroup):
     pc_weights = pb_weights
 
 
+class ResponseMetrics(MetricGroup):
+    """R rows (#134): responses conditioned on the stimulus they react to.
+    Rows are added step by step; the helpers below are the shared
+    derivations. Contribution change dc = c_{t+1} - c_t sits at the
+    stimulus round t and is NaN unless both contributions are valid."""
+
+    KINDS = {}
+
+    def _with_dc(self, df):
+        df = df.sort_values(PARTICIPANT + ["round_number"]).copy()
+        by_player = df.groupby(PARTICIPANT)
+        df["next_contribution"] = by_player["contribution"].shift(-1)
+        df["dc"] = df["next_contribution"] - df["contribution"]
+        return df
+
+    def _round_types(self, df):
+        """Label each agent-round with its RCA round type. Timed-out
+        choices at decision rounds are no choice at all and stay
+        unlabelled (NA), like every row the taxonomy does not cover."""
+        df = df.sort_values(PARTICIPANT + ["round_number"]).copy()
+        members = df.groupby(GROUP_CELL)["participant_code"].agg(frozenset)
+        now = members.reindex(
+            list(zip(df["episode_id"], df["round_number"], df["group_id"]))
+        ).to_numpy()
+        nxt = members.reindex(
+            list(zip(df["episode_id"], df["round_number"] + 1, df["group_id"]))
+        ).to_numpy()
+        unchanged = pd.Series([a == b for a, b in zip(now, nxt)], index=df.index)
+
+        round_type = pd.Series(pd.NA, index=df.index, dtype="object")
+        round_type[~df["switch_mask"]] = "no_switch_allowed"
+        round_type[df["switch_valid"] & df["does_switch"]] = "switched"
+        stayed = df["switch_valid"] & ~df["does_switch"]
+        round_type[stayed & unchanged] = "chose_to_stay"
+        round_type[stayed & ~unchanged] = "stayed_comp_changed"
+        df["round_type"] = round_type
+        return df
+
+    def _switch_events(self, df):
+        """One row per switch event, anchored at the decision round n:
+        own contribution at n and n+1 (dc), and the receiving group's
+        mean contribution at n -- the roster the switcher saw, which
+        they are not part of. NaN receiving_mean when the receiving
+        group was empty at n."""
+        df = self._with_dc(df)
+        by_player = df.groupby(PARTICIPANT)
+        df["next_group"] = by_player["group_id"].shift(-1)
+        events = df[df["does_switch"]].copy()
+        means = df.groupby(GROUP_CELL)["contribution"].mean()
+        keys = list(
+            zip(
+                events["episode_id"],
+                events["round_number"],
+                events["next_group"].astype(int),
+            )
+        )
+        events["receiving_mean"] = means.reindex(keys).to_numpy()
+        return events[
+            PARTICIPANT
+            + [
+                "round_number",
+                "contribution",
+                "next_contribution",
+                "dc",
+                "receiving_mean",
+            ]
+        ]
+
+
 GROUPS = {
     "C": ContributionMetrics(),
     "S": SwitchingMetrics(),

--- a/src/aimanager/tests/test_eval_metrics.py
+++ b/src/aimanager/tests/test_eval_metrics.py
@@ -228,6 +228,10 @@ def test_human_response_pins(human):
     # 539 Q4-study events minus 26 tainted by no-input masking
     events = R._switch_events(human).dropna(subset=["dc", "receiving_mean"])
     assert len(events) == 513
+    rsa = R.rsa(human)
+    assert rsa.loc["1-3"] == pytest.approx(0.2966, abs=1e-4)
+    assert rsa.loc["16+"] == pytest.approx(0.7347, abs=1e-4)
+    assert R.weights("RSA", human).to_dict() == {"1-3": 290, "4-15": 250, "16+": 49}
     assert R.weights("RCA", human).to_dict() == {
         "no_switch_allowed": 6902,
         "stayed_comp_changed": 1102,
@@ -403,13 +407,15 @@ def test_rcc_contrast(response_frame):
 @pytest.fixture()
 def pull_frame():
     """Two episodes, one switch each, engineered for an exact pull slope:
-    event 1 gap +4 with dc +2, event 2 gap -2 with dc -1 -> slope 0.5."""
+    event 1 gap +4 with dc +2, event 2 gap -2 with dc -1 -> slope 0.5.
+    Decision-round punishments hit each RSA bin once: s1 (2, switches),
+    p (5, stays), s2 (17, switches); q is unpunished and drops out."""
     rows = [
-        (0, "s1", 3, 0, 6.0, 0.0, True, True, True),
-        (0, "p", 3, 1, 10.0, 0.0, False, True, True),
+        (0, "s1", 3, 0, 6.0, 2.0, True, True, True),
+        (0, "p", 3, 1, 10.0, 5.0, False, True, True),
         (0, "s1", 4, 1, 8.0, 0.0, False, False, False),
         (0, "p", 4, 1, 10.0, 0.0, False, False, False),
-        (1, "s2", 3, 0, 8.0, 0.0, True, True, True),
+        (1, "s2", 3, 0, 8.0, 17.0, True, True, True),
         (1, "q", 3, 1, 6.0, 0.0, False, True, True),
         (1, "s2", 4, 1, 7.0, 0.0, False, False, False),
         (1, "q", 4, 1, 6.0, 0.0, False, False, False),
@@ -442,6 +448,26 @@ def test_rcd_d(pull_frame):
         "contribution",
     ] = 5.0
     assert R.d("RCD", pull_frame, moved) == pytest.approx(1 / 3)
+
+
+def test_rsa_shares_and_weights(pull_frame):
+    stat = R.rsa(pull_frame)
+    assert stat.to_dict() == pytest.approx({"1-3": 1.0, "4-15": 0.0, "16+": 1.0})
+    assert R.weights("RSA", pull_frame).to_dict() == {
+        "1-3": 1,
+        "4-15": 1,
+        "16+": 1,
+    }
+
+
+def test_rsa_d(pull_frame):
+    # punish q with 3: the 1-3 bin gains a stayer, share 1.0 -> 0.5
+    other = pull_frame.copy()
+    other.loc[
+        (other["participant_code"] == "q") & (other["round_number"] == 3),
+        "punishment",
+    ] = 3.0
+    assert R.d("RSA", pull_frame, other) == pytest.approx(1 / 6)
 
 
 def test_switch_events(response_frame):

--- a/src/aimanager/tests/test_eval_metrics.py
+++ b/src/aimanager/tests/test_eval_metrics.py
@@ -256,7 +256,7 @@ def test_human_response_pins(human):
 def test_all_metrics_extract_from_sim():
     sims = load_sim(REPO / SIM_EXAMPLE_FILE)
     sim = sims[sorted(sims)[0]]
-    for group in [C, S, P]:
+    for group in [C, S, P, R]:
         for name, e in group.extract_all(sim).items():
             assert len(e) > 0, name
             assert not e.isna().any(), name
@@ -560,7 +560,7 @@ def test_switch_events(response_frame):
 
 def test_d_self_comparison_is_zero(human):
     half = human[human["episode_id"] < human["episode_id"].median()]
-    for group in [C, S, P]:
+    for group in [C, S, P, R]:
         for name in group.KINDS:
             assert group.d(name, human, human) == pytest.approx(0), name
             # callable on episode subsets, still zero against itself

--- a/src/aimanager/tests/test_eval_metrics.py
+++ b/src/aimanager/tests/test_eval_metrics.py
@@ -234,20 +234,13 @@ def test_d_distribution_is_emd(frame):
     assert C.d("CD", frame, shifted) == pytest.approx(2.0)
 
 
-def test_d_statistic_uniform_over_present_strata(frame):
-    # +2 only in round 0: per-round |diff| = [2, 0, 0], uniform weights
-    # renormalise over the 3 rounds present (of the 24 fixed strata)
+def test_d_statistic_weighted_mean(frame):
+    # +2 only in round 0: per-round |diff| = [2, 0, 0]; explicit uniform
+    # weights over the synthetic frame's 3 rounds
     bumped = frame.copy()
     bumped.loc[bumped["round_number"] == 0, "contribution"] += 2
-    assert C.d("CB", frame, bumped) == pytest.approx(2 / 3)
-
-
-def test_d_statistic_renormalises_over_missing_strata(frame):
-    # comparison side lacks round 2: weights renormalise over rounds 0-1
-    bumped = frame.copy()
-    bumped.loc[bumped["round_number"] == 0, "contribution"] += 2
-    bumped = bumped[bumped["round_number"] < 2]
-    assert C.d("CB", frame, bumped) == pytest.approx(1.0)
+    w = pd.Series({0: 1.0, 1: 1.0, 2: 1.0})
+    assert C.d("CB", frame, bumped, weights=w) == pytest.approx(2 / 3)
 
 
 def test_d_accepts_precomputed_weights(frame):
@@ -256,6 +249,17 @@ def test_d_accepts_precomputed_weights(frame):
     bumped.loc[bumped["round_number"] == 0, "contribution"] += 2
     w = pd.Series({0: 1.0, 1: 3.0, 2: 4.0})
     assert C.d("CB", frame, bumped, weights=w) == pytest.approx(2 / 8)
+
+
+def test_d_raises_on_empty_stratum(frame):
+    # comparison side lacks round 2 entirely
+    other = frame[frame["round_number"] < 2]
+    w = pd.Series({0: 1.0, 1: 1.0, 2: 1.0})
+    with pytest.raises(ValueError, match="CB: empty strata \\[2\\]"):
+        C.d("CB", frame, other, weights=w)
+    # default weights span all 24 rounds, so a 3-round frame raises too
+    with pytest.raises(ValueError, match="empty strata"):
+        C.d("CB", frame, frame)
 
 
 def test_uniform_precomputed_weights():

--- a/src/aimanager/tests/test_eval_metrics.py
+++ b/src/aimanager/tests/test_eval_metrics.py
@@ -232,6 +232,19 @@ def test_human_response_pins(human):
     assert rsa.loc["1-3"] == pytest.approx(0.2966, abs=1e-4)
     assert rsa.loc["16+"] == pytest.approx(0.7347, abs=1e-4)
     assert R.weights("RSA", human).to_dict() == {"1-3": 290, "4-15": 250, "16+": 49}
+    assert R.weights("RPA", human).to_dict() == {
+        "{0}": 809,
+        "1-5": 1955,
+        "6-10": 2614,
+        "11-15": 1794,
+        "16-19": 510,
+        "{20}": 1232,
+    }
+    assert R.weights("RPB", human).to_dict() == {
+        "1-3": 1462,
+        "4-5": 1940,
+        "6-8": 4331,
+    }
     assert R.weights("RCA", human).to_dict() == {
         "no_switch_allowed": 6902,
         "stayed_comp_changed": 1102,
@@ -468,6 +481,71 @@ def test_rsa_d(pull_frame):
         "punishment",
     ] = 3.0
     assert R.d("RSA", pull_frame, other) == pytest.approx(1 / 6)
+
+
+def test_rpa_observations(frame):
+    # bins from the C/P fixture: {0}: [0, 30], 1-5: [0], 6-10: [5, 0, 0],
+    # 11-15: [0], {20}: [0, 10, 0, 0]; a's all-NaN round 1 drops; the
+    # 16-19 bin has no observations in this frame
+    obs = R.rpa(frame)
+    by_bin = {k: sorted(v.tolist()) for k, v in obs.groupby(level=0)}
+    assert by_bin == {
+        "{0}": [0.0, 30.0],
+        "1-5": [0.0],
+        "6-10": [0.0, 0.0, 5.0],
+        "11-15": [0.0],
+        "{20}": [0.0, 0.0, 0.0, 10.0],
+    }
+    assert R.weights("RPA", frame).to_dict() == {
+        "{0}": 2,
+        "1-5": 1,
+        "6-10": 3,
+        "11-15": 1,
+        "{20}": 4,
+    }
+
+
+def test_rpa_d(frame):
+    # raise d's round-0 punishment 10 -> 14: only the {20} bin moves,
+    # EMD = 4/4, weighted by 4 of 11 observations
+    bumped = frame.copy()
+    bumped.loc[
+        (bumped["participant_code"] == "d") & (bumped["round_number"] == 0),
+        "punishment",
+    ] = 14.0
+    assert R.d("RPA", frame, bumped) == pytest.approx(4 / 11)
+    assert R.d("RPA", frame, frame) == pytest.approx(0)
+
+
+def test_rpb_group_size_bins():
+    # 8 players: round 4 split 6-2, round 5 split 4-4; round 3 excluded
+    players = list("abcdefgh")
+    rows = [(0, p, 3, 0, 99.0) for p in players]
+    rows += [
+        (0, p, 4, 0 if p < "g" else 1, float(i))
+        for i, p in enumerate(players)  # g0 {a..f} p 0..5, g1 {g,h} p 6,7
+    ]
+    rows += [
+        (0, p, 5, 0 if p < "e" else 1, 1.0)
+        for p in players  # 4-4 split, all punished 1
+    ]
+    df = pd.DataFrame(
+        rows,
+        columns=[
+            "episode_id",
+            "participant_code",
+            "round_number",
+            "group_id",
+            "punishment",
+        ],
+    )
+    obs = R.rpb(df)
+    by_bin = {k: sorted(v.tolist()) for k, v in obs.groupby(level=0)}
+    assert by_bin["6-8"] == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+    assert by_bin["1-3"] == [6.0, 7.0]
+    assert by_bin["4-5"] == [1.0] * 8
+    assert 99.0 not in obs.tolist()  # rounds < 4 excluded
+    assert R.weights("RPB", df).to_dict() == {"1-3": 2, "4-5": 8, "6-8": 6}
 
 
 def test_switch_events(response_frame):

--- a/src/aimanager/tests/test_eval_metrics.py
+++ b/src/aimanager/tests/test_eval_metrics.py
@@ -224,6 +224,10 @@ def test_human_response_pins(human):
         ">1": 277,
     }
     assert R.rcc(human).loc["contrast"] == pytest.approx(-7.035, abs=1e-3)
+    assert R.rcd(human).loc["pull"] == pytest.approx(0.430247, abs=1e-5)
+    # 539 Q4-study events minus 26 tainted by no-input masking
+    events = R._switch_events(human).dropna(subset=["dc", "receiving_mean"])
+    assert len(events) == 513
     assert R.weights("RCA", human).to_dict() == {
         "no_switch_allowed": 6902,
         "stayed_comp_changed": 1102,
@@ -394,6 +398,50 @@ def test_rcc_contrast(response_frame):
         "contribution",
     ] = 20.0
     assert R.d("RCC", response_frame, bumped) == pytest.approx(2.0)
+
+
+@pytest.fixture()
+def pull_frame():
+    """Two episodes, one switch each, engineered for an exact pull slope:
+    event 1 gap +4 with dc +2, event 2 gap -2 with dc -1 -> slope 0.5."""
+    rows = [
+        (0, "s1", 3, 0, 6.0, 0.0, True, True, True),
+        (0, "p", 3, 1, 10.0, 0.0, False, True, True),
+        (0, "s1", 4, 1, 8.0, 0.0, False, False, False),
+        (0, "p", 4, 1, 10.0, 0.0, False, False, False),
+        (1, "s2", 3, 0, 8.0, 0.0, True, True, True),
+        (1, "q", 3, 1, 6.0, 0.0, False, True, True),
+        (1, "s2", 4, 1, 7.0, 0.0, False, False, False),
+        (1, "q", 4, 1, 6.0, 0.0, False, False, False),
+    ]
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "episode_id",
+            "participant_code",
+            "round_number",
+            "group_id",
+            "contribution",
+            "punishment",
+            "does_switch",
+            "switch_mask",
+            "switch_valid",
+        ],
+    )
+
+
+def test_rcd_pull_slope(pull_frame):
+    assert R.rcd(pull_frame).loc["pull"] == pytest.approx(0.5)
+
+
+def test_rcd_d(pull_frame):
+    # s2 lands on 5 instead of 7: dc -1 -> -3, slope (2+3)/(4+2) = 5/6
+    moved = pull_frame.copy()
+    moved.loc[
+        (moved["participant_code"] == "s2") & (moved["round_number"] == 4),
+        "contribution",
+    ] = 5.0
+    assert R.d("RCD", pull_frame, moved) == pytest.approx(1 / 3)
 
 
 def test_switch_events(response_frame):

--- a/src/aimanager/tests/test_eval_metrics.py
+++ b/src/aimanager/tests/test_eval_metrics.py
@@ -213,6 +213,25 @@ def test_human_punishment_pins(human):
     assert extractions["PC"].loc[0] == pytest.approx(0.445055, abs=1e-5)
 
 
+def test_human_response_pins(human):
+    rcb = R.rcb(human)
+    assert rcb.loc["(0,0.25]"] == pytest.approx(0.892, abs=1e-3)
+    assert rcb.loc[">1"] == pytest.approx(2.014, abs=1e-3)
+    assert R.weights("RCB", human).to_dict() == {
+        "(0,0.25]": 1238,
+        "(0.25,0.5]": 672,
+        "(0.5,1]": 473,
+        ">1": 277,
+    }
+    assert R.rcc(human).loc["contrast"] == pytest.approx(-7.035, abs=1e-3)
+    assert R.weights("RCA", human).to_dict() == {
+        "no_switch_allowed": 6902,
+        "stayed_comp_changed": 1102,
+        "switched": 538,
+        "chose_to_stay": 182,
+    }
+
+
 def test_all_metrics_extract_from_sim():
     sims = load_sim(REPO / SIM_EXAMPLE_FILE)
     sim = sims[sorted(sims)[0]]
@@ -225,19 +244,21 @@ def test_all_metrics_extract_from_sim():
 @pytest.fixture()
 def response_frame():
     """Two episodes, decision round 3, arrival round 4. Episode 0: a
-    switches g0 -> g1 (b's group shrinks, c/d's group grows). Episode 1:
+    switches g0 -> g1 (b's group shrinks, c/d's group grows); a, c, b, d
+    are punished with shortfall rates 0.5, 0.125, 13/12, 9/14. Episode 1:
     nobody switches (pure chose-to-stay), h's choice timed out, e gave
-    no input at round 4."""
+    no input at round 4 (their round-3 punishment drops from RCB), i is
+    a punished full contributor and j an unpunished one (RCC)."""
     rows = [
         # episode 0, rounds 2-5
-        (0, "a", 2, 0, 10.0, 0.0, False, False, False),
+        (0, "a", 2, 0, 10.0, 5.0, False, False, False),
         (0, "b", 2, 0, 8.0, 0.0, False, False, False),
-        (0, "c", 2, 1, 4.0, 0.0, False, False, False),
+        (0, "c", 2, 1, 4.0, 2.0, False, False, False),
         (0, "d", 2, 1, 6.0, 0.0, False, False, False),
         (0, "a", 3, 0, 12.0, 0.0, True, True, True),
-        (0, "b", 3, 0, 8.0, 0.0, False, True, True),
+        (0, "b", 3, 0, 8.0, 13.0, False, True, True),
         (0, "c", 3, 1, 4.0, 0.0, False, True, True),
-        (0, "d", 3, 1, 6.0, 0.0, False, True, True),
+        (0, "d", 3, 1, 6.0, 9.0, False, True, True),
         (0, "a", 4, 1, 5.0, 0.0, False, False, False),
         (0, "b", 4, 0, 9.0, 0.0, False, False, False),
         (0, "c", 4, 1, 3.0, 0.0, False, False, False),
@@ -247,14 +268,18 @@ def response_frame():
         (0, "c", 5, 1, 3.0, 0.0, False, False, False),
         (0, "d", 5, 1, 7.0, 0.0, False, False, False),
         # episode 1, rounds 3-4
-        (1, "e", 3, 0, 11.0, 0.0, False, True, True),
+        (1, "e", 3, 0, 11.0, 6.0, False, True, True),
         (1, "f", 3, 0, 12.0, 0.0, False, True, True),
         (1, "g", 3, 1, 13.0, 0.0, False, True, True),
         (1, "h", 3, 1, 14.0, 0.0, False, True, False),
+        (1, "i", 3, 0, 20.0, 4.0, False, True, True),
+        (1, "j", 3, 1, 20.0, 0.0, False, True, True),
         (1, "e", 4, 0, np.nan, 0.0, False, False, False),
         (1, "f", 4, 0, 12.0, 0.0, False, False, False),
         (1, "g", 4, 1, 13.0, 0.0, False, False, False),
         (1, "h", 4, 1, 14.0, 0.0, False, False, False),
+        (1, "i", 4, 0, 14.0, 0.0, False, False, False),
+        (1, "j", 4, 1, 18.0, 0.0, False, False, False),
     ]
     return pd.DataFrame(
         rows,
@@ -299,7 +324,8 @@ def test_rca_observations(response_frame):
     by_type = {k: sorted(v.tolist()) for k, v in obs.groupby(level=0)}
     assert by_type["switched"] == [-7.0]
     assert by_type["stayed_comp_changed"] == [-1.0, 1.0, 1.0]
-    assert by_type["chose_to_stay"] == [0.0, 0.0]  # e's NaN dc drops
+    # e's NaN dc drops; i and j (full contributors) fall by -6 and -2
+    assert by_type["chose_to_stay"] == [-6.0, -2.0, 0.0, 0.0]
     # ep0 rounds 2 and 4 only: ep0 r5 and all ep1 r4 rows have no next round
     assert len(by_type["no_switch_allowed"]) == 8
 
@@ -309,20 +335,20 @@ def test_rca_weights_are_human_frequencies(response_frame):
     assert w.to_dict() == {
         "no_switch_allowed": 8,
         "stayed_comp_changed": 3,
-        "chose_to_stay": 2,
+        "chose_to_stay": 4,
         "switched": 1,
     }
 
 
 def test_rca_d_weighted_stratum_emd(response_frame):
     # bump a's round-5 contribution: only one no_switch_allowed dc moves
-    # 0 -> 4, so EMD(nsa) = 4/8 and d = (4/8) * 8/14 = 2/7
+    # 0 -> 4, so EMD(nsa) = 4/8 and d = (4/8) * 8/16 = 1/4
     bumped = response_frame.copy()
     bumped.loc[
         (bumped["participant_code"] == "a") & (bumped["round_number"] == 5),
         "contribution",
     ] = 9.0
-    assert R.d("RCA", response_frame, bumped) == pytest.approx(2 / 7)
+    assert R.d("RCA", response_frame, bumped) == pytest.approx(1 / 4)
     assert R.d("RCA", response_frame, response_frame) == pytest.approx(0)
 
 
@@ -331,6 +357,43 @@ def test_rca_d_raises_on_empty_stratum(response_frame):
     no_switch = response_frame.assign(does_switch=False)
     with pytest.raises(ValueError, match="RCA: empty strata \\['switched'\\]"):
         R.d("RCA", response_frame, no_switch)
+
+
+def test_rcb_stat_and_weights(response_frame):
+    # a: rate 5/10=0.5 dc +2 | c: 2/16=0.125 dc 0 | b: 13/12>1 dc +1 |
+    # d: 9/14 dc +1; e is punished but dc-invalid, i is full -> both out
+    stat = R.rcb(response_frame)
+    assert stat.to_dict() == pytest.approx(
+        {"(0,0.25]": 0.0, "(0.25,0.5]": 2.0, "(0.5,1]": 1.0, ">1": 1.0}
+    )
+    assert R.weights("RCB", response_frame).to_dict() == {
+        "(0,0.25]": 1,
+        "(0.25,0.5]": 1,
+        "(0.5,1]": 1,
+        ">1": 1,
+    }
+
+
+def test_rcb_d(response_frame):
+    # bump b's round-4 contribution 9 -> 11: only the ">1" bin's mean
+    # moves (+1 -> +3), so d = 2/4 with equal bin counts
+    bumped = response_frame.copy()
+    bumped.loc[
+        (bumped["participant_code"] == "b") & (bumped["round_number"] == 4),
+        "contribution",
+    ] = 11.0
+    assert R.d("RCB", response_frame, bumped) == pytest.approx(0.5)
+
+
+def test_rcc_contrast(response_frame):
+    # punished full contributor i falls -6, unpunished j falls -2
+    assert R.rcc(response_frame).loc["contrast"] == pytest.approx(-4.0)
+    bumped = response_frame.copy()
+    bumped.loc[
+        (bumped["participant_code"] == "j") & (bumped["round_number"] == 4),
+        "contribution",
+    ] = 20.0
+    assert R.d("RCC", response_frame, bumped) == pytest.approx(2.0)
 
 
 def test_switch_events(response_frame):

--- a/src/aimanager/tests/test_eval_metrics.py
+++ b/src/aimanager/tests/test_eval_metrics.py
@@ -20,6 +20,7 @@ from aimanager.evaluation_suite.convert import (
 from aimanager.evaluation_suite.metrics import (
     ContributionMetrics,
     PunishmentMetrics,
+    ResponseMetrics,
     SwitchingMetrics,
 )
 
@@ -28,6 +29,7 @@ REPO = Path(__file__).resolve().parents[3]
 C = ContributionMetrics()
 S = SwitchingMetrics()
 P = PunishmentMetrics()
+R = ResponseMetrics()
 
 
 @pytest.fixture(scope="module")
@@ -218,6 +220,88 @@ def test_all_metrics_extract_from_sim():
         for name, e in group.extract_all(sim).items():
             assert len(e) > 0, name
             assert not e.isna().any(), name
+
+
+@pytest.fixture()
+def response_frame():
+    """Two episodes, decision round 3, arrival round 4. Episode 0: a
+    switches g0 -> g1 (b's group shrinks, c/d's group grows). Episode 1:
+    nobody switches (pure chose-to-stay), h's choice timed out, e gave
+    no input at round 4."""
+    rows = [
+        # episode 0, rounds 2-5
+        (0, "a", 2, 0, 10.0, 0.0, False, False, False),
+        (0, "b", 2, 0, 8.0, 0.0, False, False, False),
+        (0, "c", 2, 1, 4.0, 0.0, False, False, False),
+        (0, "d", 2, 1, 6.0, 0.0, False, False, False),
+        (0, "a", 3, 0, 12.0, 0.0, True, True, True),
+        (0, "b", 3, 0, 8.0, 0.0, False, True, True),
+        (0, "c", 3, 1, 4.0, 0.0, False, True, True),
+        (0, "d", 3, 1, 6.0, 0.0, False, True, True),
+        (0, "a", 4, 1, 5.0, 0.0, False, False, False),
+        (0, "b", 4, 0, 9.0, 0.0, False, False, False),
+        (0, "c", 4, 1, 3.0, 0.0, False, False, False),
+        (0, "d", 4, 1, 7.0, 0.0, False, False, False),
+        (0, "a", 5, 1, 5.0, 0.0, False, False, False),
+        (0, "b", 5, 0, 9.0, 0.0, False, False, False),
+        (0, "c", 5, 1, 3.0, 0.0, False, False, False),
+        (0, "d", 5, 1, 7.0, 0.0, False, False, False),
+        # episode 1, rounds 3-4
+        (1, "e", 3, 0, 11.0, 0.0, False, True, True),
+        (1, "f", 3, 0, 12.0, 0.0, False, True, True),
+        (1, "g", 3, 1, 13.0, 0.0, False, True, True),
+        (1, "h", 3, 1, 14.0, 0.0, False, True, False),
+        (1, "e", 4, 0, np.nan, 0.0, False, False, False),
+        (1, "f", 4, 0, 12.0, 0.0, False, False, False),
+        (1, "g", 4, 1, 13.0, 0.0, False, False, False),
+        (1, "h", 4, 1, 14.0, 0.0, False, False, False),
+    ]
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "episode_id",
+            "participant_code",
+            "round_number",
+            "group_id",
+            "contribution",
+            "punishment",
+            "does_switch",
+            "switch_mask",
+            "switch_valid",
+        ],
+    )
+
+
+def test_dc_values(response_frame):
+    df = R._with_dc(response_frame).set_index(
+        ["episode_id", "participant_code", "round_number"]
+    )
+    assert df.loc[(0, "a", 2), "dc"] == 2.0  # 12 - 10
+    assert df.loc[(0, "a", 3), "dc"] == -7.0  # 5 - 12, across the switch
+    assert pd.isna(df.loc[(1, "e", 3), "dc"])  # next contribution invalid
+    assert pd.isna(df.loc[(0, "a", 5), "dc"])  # last round: no next
+
+
+def test_round_types(response_frame):
+    df = R._round_types(response_frame).set_index(
+        ["episode_id", "participant_code", "round_number"]
+    )
+    assert df.loc[(0, "a", 2), "round_type"] == "no_switch_allowed"
+    assert df.loc[(0, "a", 3), "round_type"] == "switched"
+    assert df.loc[(0, "b", 3), "round_type"] == "stayed_comp_changed"  # a left
+    assert df.loc[(0, "c", 3), "round_type"] == "stayed_comp_changed"  # a joined
+    assert df.loc[(1, "f", 3), "round_type"] == "chose_to_stay"
+    assert pd.isna(df.loc[(1, "h", 3), "round_type"])  # timed out: no choice
+
+
+def test_switch_events(response_frame):
+    events = R._switch_events(response_frame)
+    assert len(events) == 1
+    e = events.iloc[0]
+    assert e["participant_code"] == "a"
+    assert e["contribution"] == 12.0
+    assert e["dc"] == -7.0
+    assert e["receiving_mean"] == 5.0  # (4 + 6) / 2, roster a saw at round 3
 
 
 def test_d_self_comparison_is_zero(human):

--- a/src/aimanager/tests/test_eval_metrics.py
+++ b/src/aimanager/tests/test_eval_metrics.py
@@ -294,6 +294,45 @@ def test_round_types(response_frame):
     assert pd.isna(df.loc[(1, "h", 3), "round_type"])  # timed out: no choice
 
 
+def test_rca_observations(response_frame):
+    obs = R.rca(response_frame)
+    by_type = {k: sorted(v.tolist()) for k, v in obs.groupby(level=0)}
+    assert by_type["switched"] == [-7.0]
+    assert by_type["stayed_comp_changed"] == [-1.0, 1.0, 1.0]
+    assert by_type["chose_to_stay"] == [0.0, 0.0]  # e's NaN dc drops
+    # ep0 rounds 2 and 4 only: ep0 r5 and all ep1 r4 rows have no next round
+    assert len(by_type["no_switch_allowed"]) == 8
+
+
+def test_rca_weights_are_human_frequencies(response_frame):
+    w = R.weights("RCA", response_frame)
+    assert w.to_dict() == {
+        "no_switch_allowed": 8,
+        "stayed_comp_changed": 3,
+        "chose_to_stay": 2,
+        "switched": 1,
+    }
+
+
+def test_rca_d_weighted_stratum_emd(response_frame):
+    # bump a's round-5 contribution: only one no_switch_allowed dc moves
+    # 0 -> 4, so EMD(nsa) = 4/8 and d = (4/8) * 8/14 = 2/7
+    bumped = response_frame.copy()
+    bumped.loc[
+        (bumped["participant_code"] == "a") & (bumped["round_number"] == 5),
+        "contribution",
+    ] = 9.0
+    assert R.d("RCA", response_frame, bumped) == pytest.approx(2 / 7)
+    assert R.d("RCA", response_frame, response_frame) == pytest.approx(0)
+
+
+def test_rca_d_raises_on_empty_stratum(response_frame):
+    # a comparison side that never switches has no "switched" stratum
+    no_switch = response_frame.assign(does_switch=False)
+    with pytest.raises(ValueError, match="RCA: empty strata \\['switched'\\]"):
+        R.d("RCA", response_frame, no_switch)
+
+
 def test_switch_events(response_frame):
     events = R._switch_events(response_frame)
     assert len(events) == 1


### PR DESCRIPTION
Closes #134 — the R (response) metrics, completing the 19-row evaluation suite started in #133 (#128). Responses are conditioned on the stimulus they react to: these check whether the models have the right *mechanisms*, where the C/S/P distributions checked for the right *states*. Definitions in `notes/evaluation_metric_defs.md`.

## Settled in this branch

- **RCB punishment rate = punishment / (20 − contribution)** — punishment per point of shortfall; "> 1" = punished more than the entire shortfall; undefined exactly at contribution 20, which is the ceiling case RCC exists for. On the human data the bins are well-populated (1238/672/473/277) with a clean monotone reaction.
- **Empty strata: assumed absent, enforced by error.** `d()` raises naming the row and missing strata if any weighted stratum is empty on either side; a policy gets designed only if a real candidate model triggers it. Census: every R stratum is populated in the human data (also in 25-episode halves) and all committed sims — closest call is lin_ridge's RSA 16+ bin at n=6.
- **Weight scheme finalized**: design-fixed strata (all C/S/P) uniform precomputed; behaviour-conditioned strata (R bins) human-frequency, fixed from the full deduped human data (#132). RCA's human shares justify it: 79.1 / 12.6 / 6.2 / 2.1% across round types.

## What's here (one commit per step, reviewable in order)

1. Settled definitions in the metric defs doc; strict empty-stratum guard in `d()` (replaces #133's silent renormalisation).
2. **Scaffolding** — `ResponseMetrics` with the shared derivations: Δc at the stimulus round, round-type labels via actual membership-set comparison (timed-out choices stay unlabelled — a timeout is no choice), switch events with the receiving group's roster mean.
3. **RCA** — Δc by round type; introduces the third row kind, `stratified_distribution` (weighted mean of per-stratum EMDs), reused by RPA/RPB.
4. **RCB + RCC** — reaction to punishment by shortfall-rate bin; ceiling contrast.
5. **RCD** — switching pull slope. Cross-checked: our event frames reproduce PR #131's Q4 table **exactly** on all three sim rows and on the human row under legacy zero-filling (539 / +0.464 / +0.284); the suite's official human numbers are n=513 / +0.477 / +0.320 after no-input masking.
6. **RSA** — switch share after punishment by size bin.
7. **RPA + RPB** — punishment distribution by contribution bin (the policy shape) and by group-size bin.
8. **Integration** — `GROUPS` gains R; `evaluate`/`metrics.csv` cover all 19 rows with no `evaluate.py` changes; committed run output refreshed (57 rows).

## R results (raw units, unnormalised — #132 normalises)

| metric | | lin_gaussian | lin_multinomial | lin_ridge |
|---|---|---|---|---|
| RCA | Δc by round type | 1.58 | 1.62 | 1.58 |
| RCB | reaction to punishment | 0.87 | 0.86 | 0.97 |
| RCC | ceiling contrast | 7.16 | 6.35 | 7.07 |
| RCD | switching pull | 0.08 | 0.04 | 0.06 |
| RSA | flight after punishment | 0.08 | 0.09 | 0.12 |
| RPA | policy by contribution | 2.19 | **0.81** | 2.39 |
| RPB | policy by group size | 1.99 | **0.17** | 2.31 |

Findings:

- **The punishment-reaction mechanism is inverted in all sims** (RCB): humans raise contributions more the harder they're punished (+0.89 → +2.01 across bins); every sim goes *negative* in the harshest bin (−0.7 to −1.4). Consistent with `prev_punishment` being a near-zero driver in the contribution models (#131) — what looks like reaction is mean reversion.
- **The ceiling reaction is absent** (RCC): humans punished at full contribution crash −7.0 next round; sims ≈ 0. Largest raw number on the board.
- **Switching mechanisms are roughly right** (RCD, RSA): pull 0.35–0.39 vs human 0.43; flight escalates with punishment in both, sims under-flee mid-range (0.39 vs 0.54).
- **Manager policy shape** (RPA): humans discriminate 18:1 by contribution (4.76 at c=0 → 0.27 at c=20); multinomial has the right direction at 2:1, ridge/gaussian are nearly flat — multinomial again the only human-like punisher, as in the P rows of #133.

## Testing

- [x] 50 evaluation tests pass locally (pure pandas); black + flake8 clean; every R metric pinned on a hand-computed frame and on the human reference
- [ ] Full suite on Raven via `scripts/remote_test.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
