### PR TITLE
Implement the scoring schema for the eval metrics (#132)

### DIFF
--- a/notes/eval_scoring_schema.md
+++ b/notes/eval_scoring_schema.md
@@ -44,7 +44,11 @@ One repeat:
 
 One split is itself random, so repeat ~500 times with fresh shuffles
 (one fixed seed, so every model sees identical splits and draws).
-Average the model pieces, average the floor pieces, divide:
+If a draw cannot support every stratum of a row (a rare behaviour the
+sim almost never shows), that repeat is dropped for that row and the
+count of surviving repeats is reported; below half surviving, the score
+is NaN with a warning. Average the model pieces, average the floor
+pieces, divide:
 
     score = typical human-vs-sim distance / typical human-vs-human distance
 

--- a/notes/eval_scoring_schema.md
+++ b/notes/eval_scoring_schema.md
@@ -1,0 +1,74 @@
+# The Evaluation Scoring Schema
+
+How the raw evaluation metrics (#128, #134) become comparable scores (#132).
+Three layers, bottom to top.
+
+## Layer 1: one comparison is one number, d
+
+Every metric row knows how to compare any two datasets and return one
+number, d. The weights live here, inside a single d -- never in the
+scoring loop above.
+
+- **CD (raw contributions):** pool both sides' contributions, compute the
+  earth mover's distance between them.
+- **CB (round means):** per round, the absolute difference of the two
+  means; average the 24 rounds equally. Rounds are equally populated by
+  the game's design, so uniform weights (same for all C/S/P rows).
+- **RCA (reaction by round type):** an EMD within each round type,
+  averaged with the types' human presence rates (79% of rows are
+  no-switch rounds, only 2% are chose-to-stay -- a rare bin should not
+  count like a common one). Same idea for all R rows.
+
+The weights are computed once from the full human data and reused in
+every comparison, so every model is measured with the same yardstick.
+
+## Layer 2: the problem -- a lone d means nothing
+
+Say d(human, sim) = 1.6 for CD. Bad? There is nothing to compare it to.
+And part of that 1.6 is not model error at all: 50 episodes is a small
+sample, and if the human experiment were run twice, the two datasets
+would not match either. Every row has a floor below which no model can
+go, and the floor differs per row.
+
+## Layer 3: measure the floor with humans vs humans
+
+One repeat:
+
+- shuffle the 50 human episodes, split into halves h_a and h_b (25 each)
+- **floor piece:** d(h_a, h_b) -- how far two same-sized groups of real
+  humans are apart. For CD this is about 1.08. A perfect model cannot
+  beat this: h_b IS a perfect model of humans, and 1.08 is what it gets.
+- **model piece:** d(h_a, s), with s = 25 random sim episodes. Same
+  reference half, same sample size, so small-sample inflation hits both
+  pieces equally and cancels.
+
+One split is itself random, so repeat ~500 times with fresh shuffles
+(one fixed seed, so every model sees identical splits and draws).
+Average the model pieces, average the floor pieces, divide:
+
+    score = typical human-vs-sim distance / typical human-vs-human distance
+
+## Reading a score
+
+"How many times farther from humans is this model than humans are from
+themselves?"
+
+- **~1** -- at the ceiling; indistinguishable from a second human sample.
+  Below 1 happens when a sim is smoother than humans; read it as "at the
+  ceiling" too.
+- **1-2** -- minor deviation.
+- **2-5** -- clear deviation.
+- **> 5** -- not reproduced.
+
+Examples from the linear-stack run (`22_2g8a_linear_self_ridge_contr`):
+
+- PA for lin_ridge: raw d ~2.3 becomes **7.4** -- seven times outside
+  natural human variation; the punishment distribution is simply wrong.
+- PA for lin_multinomial: **0.63** -- at the ceiling.
+- RCC (the ceiling-punishment reaction): the scariest raw number on the
+  board (~7.0) becomes a mild **1.7**, because its own human floor is 4.4
+  -- a contrast built on 44 events is naturally that unstable.
+
+That is the point of the schema: raw d values are apples and oranges
+across rows; scores are all in one unit, multiples of natural human
+variation.

--- a/notes/evaluation_metric_defs.md
+++ b/notes/evaluation_metric_defs.md
@@ -117,11 +117,16 @@ models have the right mechanisms, not just the right states. Contribution change
 means next round's contribution minus this round's, with the stimulus taken this
 round; it requires a valid contribution in both rounds.
 
-The R rows could in principle have empty strata (a sim that never punishes
-hard or never switches produces no observations in some bins). We assume this
-does not happen: the discrepancy raises an error when an expected stratum is
-empty on either side, naming the row and the missing strata. If a real
-candidate model ever triggers it, a policy gets designed then (issue #134).
+The R rows can have empty strata (a sim that never punishes hard or never
+switches produces no observations in some bins). The discrepancy raises an
+error when an expected stratum is empty on either side, naming the row and
+the missing strata. At the scoring level (#132) the settled policy is: a
+resampling repeat whose draw cannot support every stratum is dropped, both
+score terms average over the same surviving repeats, and repeats_used is
+reported; if fewer than half the repeats survive, the score is NaN and a
+warning is emitted. Settled on the one real case that triggered it:
+lin_ridge's RSA 16+ bin (6 events in 100 episodes, 17% of draws
+unsupported).
 
 **RCA -- contribution change by round type:** how contributions change after four
 kinds of round: no switch was allowed, the player switched, the player chose to

--- a/plots/simulation/22_2g8a_linear_self_ridge_contr/scores.csv
+++ b/plots/simulation/22_2g8a_linear_self_ridge_contr/scores.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2082693fa13ea483366de3f86e2d209e29b4e9053582e9d26f8648fe20b27994
+size 6883

--- a/src/aimanager/evaluation_suite/evaluate.py
+++ b/src/aimanager/evaluation_suite/evaluate.py
@@ -5,11 +5,15 @@
 Reads the finished simulation's per_round.parquet from the config's
 output_dir (the simulation must have run with save_per_round: true),
 converts the human reference and every pairing into the canonical frame,
-and writes metrics.csv to the output_dir -- one row per (pairing, metric)
-with the raw discrepancy d(human, sim), the signed std diagnostic where
-retained (CA/CC/CE), and the observation counts. These are raw-unit
-quick-look values; the comparable normalised scores come from #132's
-scoring pipeline, which consumes the metric objects directly.
+and writes two files to the output_dir:
+
+- metrics.csv: one row per (pairing, metric) with the raw discrepancy
+  d(human, sim), the signed std diagnostic where retained (CA/CC/CE),
+  and the observation counts -- raw-unit quick-look values
+- scores.csv: the #132 normalised scores against the human-vs-human
+  noise ceiling (score, numerator, denominator, repeats_used,
+  n_repeats, seed); scoring_repeats and scoring_seed in the sim config
+  override the 500 / 42 defaults
 """
 
 import os
@@ -23,6 +27,7 @@ from aimanager.evaluation_suite.convert import (
     load_sim,
 )
 from aimanager.evaluation_suite.metrics import GROUPS
+from aimanager.evaluation_suite.scoring import score_all
 
 DIAGNOSTIC_ROWS = ["CA", "CC", "CE"]
 
@@ -76,3 +81,13 @@ def run_cli(config, config_path):
     out_path = os.path.join(output_dir, "metrics.csv")
     result.to_csv(out_path, index=False)
     print(f"{len(result)} rows ({len(sims)} pairings) -> {out_path}")
+
+    scores = score_all(
+        human,
+        sims,
+        n_repeats=config.get("scoring_repeats", 500),
+        seed=config.get("scoring_seed", 42),
+    )
+    scores_path = os.path.join(output_dir, "scores.csv")
+    scores.to_csv(scores_path, index=False)
+    print(f"{len(scores)} scores -> {scores_path}")

--- a/src/aimanager/evaluation_suite/scoring.py
+++ b/src/aimanager/evaluation_suite/scoring.py
@@ -18,6 +18,9 @@ model is scored on identical splits and simulation draws.
 import warnings
 
 import numpy as np
+import pandas as pd
+
+from aimanager.evaluation_suite.metrics import GROUPS
 
 
 def make_repeats(human_episode_ids, sim_episode_ids, n_repeats, seed):
@@ -114,3 +117,28 @@ def score_row(group, name, human, sim, repeats, weights=None, denoms=None):
         return result
     result["score"] = result["numerator"] / result["denominator"]
     return result
+
+
+def score_all(human, sims, n_repeats=500, seed=42, groups=None):
+    """Normalised scores for every metric row and pairing, as a long
+    frame. One resampling plan serves all pairings (their pools must
+    hold the same episode ids), and each row's noise ceiling is
+    computed once and shared."""
+    groups = GROUPS if groups is None else groups
+    pools = [frozenset(sim["episode_id"].unique()) for sim in sims.values()]
+    if len(set(pools)) > 1:
+        raise ValueError("sim pairings must share one episode pool")
+    repeats = make_repeats(
+        human["episode_id"].unique(), sorted(pools[0]), n_repeats, seed
+    )
+    rows = []
+    for group in groups.values():
+        for name in group.KINDS:
+            weights = _row_weights(group, name, human)
+            denoms = denominators(group, name, human, repeats, weights=weights)
+            for run, sim in sims.items():
+                result = score_row(
+                    group, name, human, sim, repeats, weights=weights, denoms=denoms
+                )
+                rows.append({"run": run, "metric": name, **result, "seed": seed})
+    return pd.DataFrame(rows)

--- a/src/aimanager/evaluation_suite/scoring.py
+++ b/src/aimanager/evaluation_suite/scoring.py
@@ -42,3 +42,38 @@ def make_repeats(human_episode_ids, sim_episode_ids, n_repeats, seed):
 def subset(df, episode_ids):
     """Canonical-frame subset for one side of a comparison."""
     return df[df["episode_id"].isin(episode_ids)]
+
+
+def _row_weights(group, name, human):
+    """Stratum weights fixed once on the full human reference; plain
+    distribution rows have none."""
+    if group.KINDS[name] == "distribution":
+        return None
+    return group.weights(name, human)
+
+
+def denominators(group, name, human, repeats, weights=None):
+    """d(h_a, h_b) per repeat -- the human-vs-human noise ceiling. It
+    does not depend on the sim, so the driver computes it once per row
+    and reuses it across pairings."""
+    if weights is None:
+        weights = _row_weights(group, name, human)
+    return [
+        group.d(name, subset(human, h_a), subset(human, h_b), weights=weights)
+        for h_a, h_b, _ in repeats
+    ]
+
+
+def score_row(group, name, human, sim, repeats, weights=None, denoms=None):
+    """Normalised score for one metric row: mean_r d(h_a, s) over
+    mean_r d(h_a, h_b), the same h_a in both terms, numerator and
+    denominator averaged separately before dividing."""
+    if weights is None:
+        weights = _row_weights(group, name, human)
+    if denoms is None:
+        denoms = denominators(group, name, human, repeats, weights=weights)
+    nums = [
+        group.d(name, subset(human, h_a), subset(sim, s), weights=weights)
+        for h_a, _, s in repeats
+    ]
+    return (sum(nums) / len(nums)) / (sum(denoms) / len(denoms))

--- a/src/aimanager/evaluation_suite/scoring.py
+++ b/src/aimanager/evaluation_suite/scoring.py
@@ -15,6 +15,8 @@ The resampling plan is fixed by one master seed, so every candidate
 model is scored on identical splits and simulation draws.
 """
 
+import warnings
+
 import numpy as np
 
 
@@ -52,14 +54,23 @@ def _row_weights(group, name, human):
     return group.weights(name, human)
 
 
+def _d_or_none(group, name, a, b, weights):
+    """One d evaluation; None when the comparison cannot support every
+    stratum (the #134 guard) -- the repeat is then dropped."""
+    try:
+        return group.d(name, a, b, weights=weights)
+    except ValueError:
+        return None
+
+
 def denominators(group, name, human, repeats, weights=None):
     """d(h_a, h_b) per repeat -- the human-vs-human noise ceiling. It
     does not depend on the sim, so the driver computes it once per row
-    and reuses it across pairings."""
+    and reuses it across pairings. None marks an unsupported repeat."""
     if weights is None:
         weights = _row_weights(group, name, human)
     return [
-        group.d(name, subset(human, h_a), subset(human, h_b), weights=weights)
+        _d_or_none(group, name, subset(human, h_a), subset(human, h_b), weights)
         for h_a, h_b, _ in repeats
     ]
 
@@ -67,13 +78,39 @@ def denominators(group, name, human, repeats, weights=None):
 def score_row(group, name, human, sim, repeats, weights=None, denoms=None):
     """Normalised score for one metric row: mean_r d(h_a, s) over
     mean_r d(h_a, h_b), the same h_a in both terms, numerator and
-    denominator averaged separately before dividing."""
+    denominator averaged separately before dividing.
+
+    Repeats whose sim draw or human half cannot support every stratum
+    are dropped; both terms average over the same surviving repeats and
+    repeats_used reports how many. If fewer than half survive, the
+    score is NaN and a warning is emitted (#134's policy, settled on
+    the one real case: lin_ridge's RSA 16+ bin)."""
     if weights is None:
         weights = _row_weights(group, name, human)
     if denoms is None:
         denoms = denominators(group, name, human, repeats, weights=weights)
     nums = [
-        group.d(name, subset(human, h_a), subset(sim, s), weights=weights)
+        _d_or_none(group, name, subset(human, h_a), subset(sim, s), weights)
         for h_a, _, s in repeats
     ]
-    return (sum(nums) / len(nums)) / (sum(denoms) / len(denoms))
+    pairs = [(n, d) for n, d in zip(nums, denoms) if n is not None and d is not None]
+    result = {
+        "score": float("nan"),
+        "numerator": float("nan"),
+        "denominator": float("nan"),
+        "repeats_used": len(pairs),
+        "n_repeats": len(repeats),
+    }
+    if not pairs:
+        warnings.warn(f"{name}: no repeat supports all strata -- score is NaN")
+        return result
+    result["numerator"] = sum(n for n, _ in pairs) / len(pairs)
+    result["denominator"] = sum(d for _, d in pairs) / len(pairs)
+    if len(pairs) < len(repeats) / 2:
+        warnings.warn(
+            f"{name}: only {len(pairs)}/{len(repeats)} repeats support all "
+            "strata -- score is NaN"
+        )
+        return result
+    result["score"] = result["numerator"] / result["denominator"]
+    return result

--- a/src/aimanager/evaluation_suite/scoring.py
+++ b/src/aimanager/evaluation_suite/scoring.py
@@ -1,0 +1,44 @@
+"""Scoring schema for the evaluation metrics (#132).
+
+Normalises every metric row against a human-vs-human noise ceiling:
+
+    score = E_r[d(h_a, s)] / E_r[d(h_a, h_b)]
+
+over R repeats, where each repeat splits the human data into disjoint
+episode-level halves h_a / h_b of m = n_human // 2 episodes and draws a
+fresh size-m sample s from the pre-simulated pool. Both terms compare
+size m against size m, so finite-sample bias cancels; a model matching
+the human data scores 1 (>= 1 up to noise: ~1 at the ceiling, 1-2 minor
+deviation, 2-5 clear deviation, > 5 not reproduced).
+
+The resampling plan is fixed by one master seed, so every candidate
+model is scored on identical splits and simulation draws.
+"""
+
+import numpy as np
+
+
+def make_repeats(human_episode_ids, sim_episode_ids, n_repeats, seed):
+    """Deterministic resampling plan: a list of (h_a, h_b, s) episode-id
+    arrays, one triple per repeat. Ids are sorted before use so the plan
+    does not depend on input order; the sim draw is without replacement
+    within a repeat."""
+    human_ids = np.asarray(sorted(human_episode_ids))
+    sim_ids = np.asarray(sorted(sim_episode_ids))
+    m = len(human_ids) // 2
+    if m < 1:
+        raise ValueError("need at least 2 human episodes to split")
+    if len(sim_ids) < m:
+        raise ValueError(f"sim pool has {len(sim_ids)} episodes, need at least m={m}")
+    rng = np.random.default_rng(seed)
+    repeats = []
+    for _ in range(n_repeats):
+        perm = rng.permutation(human_ids)
+        draw = rng.choice(sim_ids, size=m, replace=False)
+        repeats.append((perm[:m], perm[m : 2 * m], draw))
+    return repeats
+
+
+def subset(df, episode_ids):
+    """Canonical-frame subset for one side of a comparison."""
+    return df[df["episode_id"].isin(episode_ids)]

--- a/src/aimanager/tests/test_eval_evaluate.py
+++ b/src/aimanager/tests/test_eval_evaluate.py
@@ -40,12 +40,16 @@ def test_run_cli_fails_clearly_without_parquet(tmp_path, capsys):
     assert "save_per_round" in capsys.readouterr().err
 
 
-def test_run_cli_writes_metrics_csv(tmp_path):
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_run_cli_writes_metrics_and_scores(tmp_path):
     # point a minimal config at the real per_round.parquet via a symlink
     output_dir = tmp_path / "run"
     output_dir.mkdir()
     (output_dir / "per_round.parquet").symlink_to(REPO / SIM_EXAMPLE_FILE)
-    run_cli({"output_dir": str(output_dir)}, "some_config.yml")
-    out = output_dir / "metrics.csv"
-    assert out.exists()
-    assert sum(1 for _ in open(out)) == 3 * N_ROWS + 1  # 3 pairings + header
+    run_cli({"output_dir": str(output_dir), "scoring_repeats": 2}, "config.yml")
+    metrics = output_dir / "metrics.csv"
+    assert metrics.exists()
+    assert sum(1 for _ in open(metrics)) == 3 * N_ROWS + 1  # pairings + header
+    scores = output_dir / "scores.csv"
+    assert scores.exists()
+    assert sum(1 for _ in open(scores)) == 3 * N_ROWS + 1

--- a/src/aimanager/tests/test_eval_scoring.py
+++ b/src/aimanager/tests/test_eval_scoring.py
@@ -112,6 +112,21 @@ def test_unsupported_repeats_are_dropped(human, human_repeats):
     assert r["repeats_used"] == 0
 
 
+def test_score_all_shape(human):
+    # cheap smoke over the S group only: two pseudo-pairings from one pool
+    from aimanager.evaluation_suite.scoring import score_all
+
+    sims = {"self": human, "shifted": human.assign(does_switch=False)}
+    out = score_all(human, sims, n_repeats=4, seed=1, groups={"S": S})
+    assert len(out) == 3 * 2  # rows x pairings
+    assert set(out.columns) >= {"run", "metric", "score", "repeats_used", "seed"}
+    self_scores = out[out["run"] == "self"]
+    assert (self_scores["repeats_used"] == 4).all()
+    # identical seeds reproduce identical scores
+    again = score_all(human, sims, n_repeats=4, seed=1, groups={"S": S})
+    assert out["score"].equals(again["score"])
+
+
 def test_lin_ridge_rsa_partial_support(human):
     # the one real #134 case: 6 of 100 lin_ridge episodes carry a 16+
     # punishment event, so ~17% of draws cannot support the bin -- the

--- a/src/aimanager/tests/test_eval_scoring.py
+++ b/src/aimanager/tests/test_eval_scoring.py
@@ -1,0 +1,52 @@
+"""Tests for the evaluation-suite scoring schema (#132)."""
+
+import numpy as np
+import pytest
+
+from aimanager.evaluation_suite.scoring import make_repeats, subset
+
+HUMAN_IDS = list(range(0, 100, 2))  # 50 episodes, even ids
+SIM_IDS = list(range(100))
+
+
+def test_repeats_are_deterministic():
+    a = make_repeats(HUMAN_IDS, SIM_IDS, n_repeats=5, seed=42)
+    b = make_repeats(HUMAN_IDS, SIM_IDS, n_repeats=5, seed=42)
+    for (a1, a2, a3), (b1, b2, b3) in zip(a, b):
+        assert (a1 == b1).all() and (a2 == b2).all() and (a3 == b3).all()
+    # input order must not matter
+    c = make_repeats(list(reversed(HUMAN_IDS)), SIM_IDS, n_repeats=5, seed=42)
+    assert (a[0][0] == c[0][0]).all()
+    # a different seed gives a different plan
+    d = make_repeats(HUMAN_IDS, SIM_IDS, n_repeats=5, seed=43)
+    assert not (a[0][0] == d[0][0]).all()
+
+
+def test_repeats_split_properties():
+    repeats = make_repeats(HUMAN_IDS, SIM_IDS, n_repeats=20, seed=0)
+    assert len(repeats) == 20
+    for h_a, h_b, s in repeats:
+        assert len(h_a) == len(h_b) == len(s) == 25  # m = 50 // 2
+        assert set(h_a).isdisjoint(h_b)
+        assert set(h_a) | set(h_b) <= set(HUMAN_IDS)
+        assert set(s) <= set(SIM_IDS)
+        assert len(set(s)) == 25  # draw without replacement
+
+
+def test_repeats_vary_across_repeats():
+    repeats = make_repeats(HUMAN_IDS, SIM_IDS, n_repeats=2, seed=0)
+    assert set(repeats[0][0]) != set(repeats[1][0])
+    assert set(repeats[0][2]) != set(repeats[1][2])
+
+
+def test_sim_pool_too_small_raises():
+    with pytest.raises(ValueError, match="need at least m=25"):
+        make_repeats(HUMAN_IDS, SIM_IDS[:10], n_repeats=1, seed=0)
+
+
+def test_subset_filters_episodes():
+    import pandas as pd
+
+    df = pd.DataFrame({"episode_id": [0, 0, 2, 4], "x": [1, 2, 3, 4]})
+    out = subset(df, np.array([0, 4]))
+    assert out["x"].tolist() == [1, 2, 4]

--- a/src/aimanager/tests/test_eval_scoring.py
+++ b/src/aimanager/tests/test_eval_scoring.py
@@ -1,12 +1,33 @@
 """Tests for the evaluation-suite scoring schema (#132)."""
 
+from pathlib import Path
+
 import numpy as np
 import pytest
 
-from aimanager.evaluation_suite.scoring import make_repeats, subset
+from aimanager.evaluation_suite.convert import HUMAN_DATA_FILE, load_human
+from aimanager.evaluation_suite.metrics import (
+    ContributionMetrics,
+    SwitchingMetrics,
+)
+from aimanager.evaluation_suite.scoring import (
+    denominators,
+    make_repeats,
+    score_row,
+    subset,
+)
 
+REPO = Path(__file__).resolve().parents[3]
 HUMAN_IDS = list(range(0, 100, 2))  # 50 episodes, even ids
 SIM_IDS = list(range(100))
+
+C = ContributionMetrics()
+S = SwitchingMetrics()
+
+
+@pytest.fixture(scope="module")
+def human():
+    return load_human(REPO / HUMAN_DATA_FILE)
 
 
 def test_repeats_are_deterministic():
@@ -50,3 +71,29 @@ def test_subset_filters_episodes():
     df = pd.DataFrame({"episode_id": [0, 0, 2, 4], "x": [1, 2, 3, 4]})
     out = subset(df, np.array([0, 4]))
     assert out["x"].tolist() == [1, 2, 4]
+
+
+@pytest.fixture(scope="module")
+def human_repeats(human):
+    ids = human["episode_id"].unique()
+    return make_repeats(ids, ids, n_repeats=40, seed=7)
+
+
+def test_human_as_sim_scores_near_one(human, human_repeats):
+    # drawing the "sim" from the human pool itself must sit at the
+    # noise ceiling for every row kind
+    for group, name in [(C, "CD"), (C, "CB"), (S, "SA")]:
+        s = score_row(group, name, human, human, human_repeats)
+        assert 0.7 < s < 1.3, (name, s)
+
+
+def test_shifted_pool_scores_far_above_one(human, human_repeats):
+    shifted = human.assign(contribution=human["contribution"] + 5)
+    assert score_row(C, "CD", human, shifted, human_repeats) > 5
+
+
+def test_precomputed_denominators_match(human, human_repeats):
+    denoms = denominators(C, "CD", human, human_repeats)
+    direct = score_row(C, "CD", human, human, human_repeats)
+    reused = score_row(C, "CD", human, human, human_repeats, denoms=denoms)
+    assert direct == pytest.approx(reused)

--- a/src/aimanager/tests/test_eval_scoring.py
+++ b/src/aimanager/tests/test_eval_scoring.py
@@ -8,6 +8,7 @@ import pytest
 from aimanager.evaluation_suite.convert import HUMAN_DATA_FILE, load_human
 from aimanager.evaluation_suite.metrics import (
     ContributionMetrics,
+    ResponseMetrics,
     SwitchingMetrics,
 )
 from aimanager.evaluation_suite.scoring import (
@@ -23,6 +24,7 @@ SIM_IDS = list(range(100))
 
 C = ContributionMetrics()
 S = SwitchingMetrics()
+R = ResponseMetrics()
 
 
 @pytest.fixture(scope="module")
@@ -83,17 +85,48 @@ def test_human_as_sim_scores_near_one(human, human_repeats):
     # drawing the "sim" from the human pool itself must sit at the
     # noise ceiling for every row kind
     for group, name in [(C, "CD"), (C, "CB"), (S, "SA")]:
-        s = score_row(group, name, human, human, human_repeats)
-        assert 0.7 < s < 1.3, (name, s)
+        r = score_row(group, name, human, human, human_repeats)
+        assert 0.7 < r["score"] < 1.3, (name, r)
+        assert r["repeats_used"] == r["n_repeats"] == 40
 
 
 def test_shifted_pool_scores_far_above_one(human, human_repeats):
     shifted = human.assign(contribution=human["contribution"] + 5)
-    assert score_row(C, "CD", human, shifted, human_repeats) > 5
+    assert score_row(C, "CD", human, shifted, human_repeats)["score"] > 5
 
 
 def test_precomputed_denominators_match(human, human_repeats):
     denoms = denominators(C, "CD", human, human_repeats)
     direct = score_row(C, "CD", human, human, human_repeats)
     reused = score_row(C, "CD", human, human, human_repeats, denoms=denoms)
-    assert direct == pytest.approx(reused)
+    assert direct["score"] == pytest.approx(reused["score"])
+
+
+def test_unsupported_repeats_are_dropped(human, human_repeats):
+    # a "sim" that never punishes >= 16 empties RSA's 16+ bin in every
+    # draw: no repeat survives, score NaN, warning emitted
+    capped = human.assign(punishment=human["punishment"].clip(upper=15))
+    with pytest.warns(UserWarning, match="RSA: no repeat supports"):
+        r = score_row(R, "RSA", human, capped, human_repeats)
+    assert np.isnan(r["score"])
+    assert r["repeats_used"] == 0
+
+
+def test_lin_ridge_rsa_partial_support(human):
+    # the one real #134 case: 6 of 100 lin_ridge episodes carry a 16+
+    # punishment event, so ~17% of draws cannot support the bin -- the
+    # score averages over the surviving repeats and reports the count
+    from aimanager.evaluation_suite.convert import SIM_EXAMPLE_FILE, load_sim
+
+    sim = load_sim(REPO / SIM_EXAMPLE_FILE)[
+        "ah group_switching managed by lin_ridge_self"
+    ]
+    repeats = make_repeats(
+        human["episode_id"].unique(),
+        sim["episode_id"].unique(),
+        n_repeats=100,
+        seed=42,
+    )
+    r = score_row(R, "RSA", human, sim, repeats)
+    assert r["repeats_used"] == 83
+    assert not np.isnan(r["score"])


### PR DESCRIPTION
Closes #132 — the scoring schema that turns the raw evaluation metrics (#133, #135) into comparable scores, normalised against a human-vs-human noise ceiling. Plain-language walkthrough in `notes/eval_scoring_schema.md`.

**score = mean_r d(h_a, s) / mean_r d(h_a, h_b)** over R = 500 repeats of disjoint 25-episode human half-splits and same-size sim draws, one fixed seed so every candidate model is scored on identical splits and draws. ≈1 at the ceiling, 1–2 minor, 2–5 clear deviation, > 5 not reproduced.

## What's here (one commit per step, reviewable in order)

1. **Split/draw machinery** — `make_repeats`: deterministic resampling plan from one master seed, input-order invariant, sim draws without replacement.
2. **Row score** — `score_row`/`denominators`: same `h_a` in both terms, numerator and denominator averaged separately; the ceiling is sim-independent, computed once per row and shared across pairings. Plus `notes/eval_scoring_schema.md`.
3. **Empty-stratum policy, settled on real data** — a 100-repeat probe found exactly one failing cell (lin_ridge's RSA 16+ bin, unsupported in 17% of draws; human halves never fail). Policy: unsupported repeats are dropped for that row, both terms average over the same survivors, `repeats_used` is reported; below half surviving the score is NaN with a warning. This closes the question #134 deferred.
4. **Driver + outputs** — `score_all`; `evaluate` now writes `scores.csv` next to `metrics.csv` (`scoring_repeats`/`scoring_seed` config keys, defaults 500/42). Committed run refreshed.

Step 5 of the issue (human-readable score-table report) is deferred until the implementation work is done.

## Scores of the committed run (500 repeats, seed 42)

| metric | lin_gaussian | lin_multinomial | lin_ridge |
|---|---|---|---|
| CA | 2.32 | 2.19 | 2.35 |
| CB | 1.27 | 0.78 | 1.04 |
| CC | 1.77 | 1.74 | 1.88 |
| CD | 1.64 | 1.44 | 1.61 |
| CE | 1.20 | 1.43 | 1.35 |
| CF | 1.75 | 1.88 | 1.91 |
| SA | 1.37 | 0.82 | 1.25 |
| SB | 1.10 | 1.22 | 1.15 |
| SC | 2.53 | 3.40 | 3.87 |
| PA | 5.95 | **0.57** | 6.85 |
| PB | 3.83 | **0.92** | 3.50 |
| PC | 7.26 | **0.84** | 7.56 |
| RCA | **5.69** | **5.82** | **5.67** |
| RCB | 2.58 | 2.60 | 2.81 |
| RCC | 1.78 | 1.60 | 1.76 |
| RCD | 1.08 | 0.74 | 0.82 |
| RSA | 1.55 | 1.66 | 2.30 † |
| RPA | 3.23 | 1.28 | 3.49 |
| RPB | 5.34 | **0.76** | 6.11 |

† scored on 402/500 supported repeats (the settled partial-support policy in action).

Normalisation rewrites the raw-table story in both directions:

- **RCA (5.7–5.8, all sims) is the worst shared row** — invisible in raw units (d ≈ 1.6) because its human noise ceiling is tiny. The sims' round-to-round reaction distributions are ~6× outside natural human variation.
- **RCC deflates** from the scariest raw number (~7.0) to a minor 1.6–1.8 — its human floor is 4.4 (a contrast on 44 events is naturally unstable).
- **lin_multinomial** sits at/below the ceiling on every punishment row (PA 0.57, PB 0.92, PC 0.84, RPB 0.76) and on RCD/SA; its failures are the shared artificial-human ones (RCA, SC, RCB, CA). ridge/gaussian punishment: 6–7.6, not reproduced.

## Testing

- [x] 61 evaluation tests pass locally (pure pandas); black + flake8 clean; the real partial-support case pinned (83/100 at seed 42), NaN + warning path covered
- [ ] Full suite on Raven via `scripts/remote_test.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
