### PR TITLE
[FAIL] Contribution self-history dropout

### DIFF
--- a/configs/simulation/manager_testing/auto_2g8a_self_selfdrop00_contr_gnn_switch.yml
+++ b/configs/simulation/manager_testing/auto_2g8a_self_selfdrop00_contr_gnn_switch.yml
@@ -1,0 +1,56 @@
+# Autoresearch contribution-self-history-dropout, Stage-1 CONTROL (p=0):
+# the 23-family template with the #114 M4 contribution model (own-group +
+# same_group features, NO input dropout) swapped in. Isolates the dropout's
+# effect from the feature set's: selfdrop15/30/50 differ from this run only
+# by the training-time masking.
+
+seed: 42
+
+artificial_humans:
+  group_switching:
+    contribution_model: artifacts/artificial_humans/group_switching_contribution_50ep_own_group_same_group/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__own_group_True__same_group_True.pt
+    valid_model: artifacts/artificial_humans/raven_script_22/model/rnn_False__dataset_full.pt
+    switch_model: artifacts/artificial_humans/switch_pred_opt_50ep_doubled_reanchored/model/architecture_mlp+rnn+edge__dataset_50ep_doubled.pt
+
+managers:
+  lin_multinomial:
+    type: linear
+    path: artifacts/baselines/punishment_multinomial_best_with_contr.joblib
+  lin_ridge:
+    type: linear
+    path: artifacts/baselines/punishment_ridge_best.joblib
+  lin_gaussian:
+    type: linear
+    path: artifacts/baselines/punishment_gaussian_best_with_contr.joblib
+  gnn:
+    type: human
+    path: artifacts/artificial_humans/punishment_rnn_edge_50ep_doubled/model/architecture_node+edge+rnn__dataset_50ep_doubled.pt
+
+pairings:
+  - name: lin_multinomial_self
+    group_0: lin_multinomial
+    group_1: lin_multinomial
+  - name: lin_ridge_self
+    group_0: lin_ridge
+    group_1: lin_ridge
+  - name: lin_gaussian_self
+    group_0: lin_gaussian
+    group_1: lin_gaussian
+  - name: gnn_self
+    group_0: gnn
+    group_1: gnn
+
+switch_every: 4
+n_episode_steps: 24
+n_episodes: 100
+n_groups: 2
+n_agents: 8
+agent_groups: [0, 0, 0, 0, 1, 1, 1, 1]
+n_contributions: 21
+n_punishments: 31
+n_rounds: 24
+
+output_dir: plots/simulation/auto_2g8a_self_selfdrop00_contr_gnn_switch
+figure_name: 2g8a_self_selfdrop00_contr_gnn_switch
+save_per_round: true
+basedir: .

--- a/configs/simulation/manager_testing/auto_2g8a_self_selfdrop15_contr_gnn_switch.yml
+++ b/configs/simulation/manager_testing/auto_2g8a_self_selfdrop15_contr_gnn_switch.yml
@@ -1,0 +1,56 @@
+# Autoresearch contribution-self-history-dropout, Stage 1: the 23-family
+# template (23_2g8a_self_gnn_contr_gnn_switch) with the candidate contribution
+# model (M4 features + prev_contribution input dropout p=0.15) swapped into
+# the contribution slot. Everything else identical; the reference-stack score
+# is the lin_multinomial_self pairing.
+
+seed: 42
+
+artificial_humans:
+  group_switching:
+    contribution_model: artifacts/artificial_humans/auto_contribution_selfdrop_15/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__own_group_True__same_group_True__self_dropout_0.15.pt
+    valid_model: artifacts/artificial_humans/raven_script_22/model/rnn_False__dataset_full.pt
+    switch_model: artifacts/artificial_humans/switch_pred_opt_50ep_doubled_reanchored/model/architecture_mlp+rnn+edge__dataset_50ep_doubled.pt
+
+managers:
+  lin_multinomial:
+    type: linear
+    path: artifacts/baselines/punishment_multinomial_best_with_contr.joblib
+  lin_ridge:
+    type: linear
+    path: artifacts/baselines/punishment_ridge_best.joblib
+  lin_gaussian:
+    type: linear
+    path: artifacts/baselines/punishment_gaussian_best_with_contr.joblib
+  gnn:
+    type: human
+    path: artifacts/artificial_humans/punishment_rnn_edge_50ep_doubled/model/architecture_node+edge+rnn__dataset_50ep_doubled.pt
+
+pairings:
+  - name: lin_multinomial_self
+    group_0: lin_multinomial
+    group_1: lin_multinomial
+  - name: lin_ridge_self
+    group_0: lin_ridge
+    group_1: lin_ridge
+  - name: lin_gaussian_self
+    group_0: lin_gaussian
+    group_1: lin_gaussian
+  - name: gnn_self
+    group_0: gnn
+    group_1: gnn
+
+switch_every: 4
+n_episode_steps: 24
+n_episodes: 100
+n_groups: 2
+n_agents: 8
+agent_groups: [0, 0, 0, 0, 1, 1, 1, 1]
+n_contributions: 21
+n_punishments: 31
+n_rounds: 24
+
+output_dir: plots/simulation/auto_2g8a_self_selfdrop15_contr_gnn_switch
+figure_name: 2g8a_self_selfdrop15_contr_gnn_switch
+save_per_round: true
+basedir: .

--- a/configs/simulation/manager_testing/auto_2g8a_self_selfdrop30_contr_gnn_switch.yml
+++ b/configs/simulation/manager_testing/auto_2g8a_self_selfdrop30_contr_gnn_switch.yml
@@ -1,0 +1,56 @@
+# Autoresearch contribution-self-history-dropout, Stage 1: the 23-family
+# template (23_2g8a_self_gnn_contr_gnn_switch) with the candidate contribution
+# model (M4 features + prev_contribution input dropout p=0.30) swapped into
+# the contribution slot. Everything else identical; the reference-stack score
+# is the lin_multinomial_self pairing.
+
+seed: 42
+
+artificial_humans:
+  group_switching:
+    contribution_model: artifacts/artificial_humans/auto_contribution_selfdrop_30/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__own_group_True__same_group_True__self_dropout_0.30.pt
+    valid_model: artifacts/artificial_humans/raven_script_22/model/rnn_False__dataset_full.pt
+    switch_model: artifacts/artificial_humans/switch_pred_opt_50ep_doubled_reanchored/model/architecture_mlp+rnn+edge__dataset_50ep_doubled.pt
+
+managers:
+  lin_multinomial:
+    type: linear
+    path: artifacts/baselines/punishment_multinomial_best_with_contr.joblib
+  lin_ridge:
+    type: linear
+    path: artifacts/baselines/punishment_ridge_best.joblib
+  lin_gaussian:
+    type: linear
+    path: artifacts/baselines/punishment_gaussian_best_with_contr.joblib
+  gnn:
+    type: human
+    path: artifacts/artificial_humans/punishment_rnn_edge_50ep_doubled/model/architecture_node+edge+rnn__dataset_50ep_doubled.pt
+
+pairings:
+  - name: lin_multinomial_self
+    group_0: lin_multinomial
+    group_1: lin_multinomial
+  - name: lin_ridge_self
+    group_0: lin_ridge
+    group_1: lin_ridge
+  - name: lin_gaussian_self
+    group_0: lin_gaussian
+    group_1: lin_gaussian
+  - name: gnn_self
+    group_0: gnn
+    group_1: gnn
+
+switch_every: 4
+n_episode_steps: 24
+n_episodes: 100
+n_groups: 2
+n_agents: 8
+agent_groups: [0, 0, 0, 0, 1, 1, 1, 1]
+n_contributions: 21
+n_punishments: 31
+n_rounds: 24
+
+output_dir: plots/simulation/auto_2g8a_self_selfdrop30_contr_gnn_switch
+figure_name: 2g8a_self_selfdrop30_contr_gnn_switch
+save_per_round: true
+basedir: .

--- a/configs/simulation/manager_testing/auto_2g8a_self_selfdrop50_contr_gnn_switch.yml
+++ b/configs/simulation/manager_testing/auto_2g8a_self_selfdrop50_contr_gnn_switch.yml
@@ -1,0 +1,56 @@
+# Autoresearch contribution-self-history-dropout, Stage 1: the 23-family
+# template (23_2g8a_self_gnn_contr_gnn_switch) with the candidate contribution
+# model (M4 features + prev_contribution input dropout p=0.50) swapped into
+# the contribution slot. Everything else identical; the reference-stack score
+# is the lin_multinomial_self pairing.
+
+seed: 42
+
+artificial_humans:
+  group_switching:
+    contribution_model: artifacts/artificial_humans/auto_contribution_selfdrop_50/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__own_group_True__same_group_True__self_dropout_0.50.pt
+    valid_model: artifacts/artificial_humans/raven_script_22/model/rnn_False__dataset_full.pt
+    switch_model: artifacts/artificial_humans/switch_pred_opt_50ep_doubled_reanchored/model/architecture_mlp+rnn+edge__dataset_50ep_doubled.pt
+
+managers:
+  lin_multinomial:
+    type: linear
+    path: artifacts/baselines/punishment_multinomial_best_with_contr.joblib
+  lin_ridge:
+    type: linear
+    path: artifacts/baselines/punishment_ridge_best.joblib
+  lin_gaussian:
+    type: linear
+    path: artifacts/baselines/punishment_gaussian_best_with_contr.joblib
+  gnn:
+    type: human
+    path: artifacts/artificial_humans/punishment_rnn_edge_50ep_doubled/model/architecture_node+edge+rnn__dataset_50ep_doubled.pt
+
+pairings:
+  - name: lin_multinomial_self
+    group_0: lin_multinomial
+    group_1: lin_multinomial
+  - name: lin_ridge_self
+    group_0: lin_ridge
+    group_1: lin_ridge
+  - name: lin_gaussian_self
+    group_0: lin_gaussian
+    group_1: lin_gaussian
+  - name: gnn_self
+    group_0: gnn
+    group_1: gnn
+
+switch_every: 4
+n_episode_steps: 24
+n_episodes: 100
+n_groups: 2
+n_agents: 8
+agent_groups: [0, 0, 0, 0, 1, 1, 1, 1]
+n_contributions: 21
+n_punishments: 31
+n_rounds: 24
+
+output_dir: plots/simulation/auto_2g8a_self_selfdrop50_contr_gnn_switch
+figure_name: 2g8a_self_selfdrop50_contr_gnn_switch
+save_per_round: true
+basedir: .

--- a/configs/training/artificial_humans/contribution/auto_selfdrop_15.yml
+++ b/configs/training/artificial_humans/contribution/auto_selfdrop_15.yml
@@ -1,0 +1,72 @@
+description: >-
+  Autoresearch experiment contribution-self-history-dropout: the M4 feature
+  set (#114: own_grp_prev_mean_contr node feature + same_group edge feature)
+  trained with training-time input dropout on prev_contribution (p=0.15).
+  Hypothesis: the GNN anchors on its own previous contribution and ignores
+  the peer signal even when handed it (PR #116: peer beta +0.03 vs human
+  +0.25); stochastically masking the self-anchor during training forces the
+  conditional distribution to load on group context. Targets RCA/RCD.
+  Identical data / CV / seed / epochs to the M4 arm; separate output_dir.
+exec:
+  command: python -m aimanager train-ah {job_file}
+  script_name: run_training
+  data_dir: artifacts
+  temp_dir: .log
+  cores: 4
+  memory: 8
+params_only: true
+params:
+  fraction_training: 1.0
+  seed: 38381
+  mask_name: contribution_valid
+  experiment_names: [ah_group_switching]
+  labels:
+    architecture: node+edge+rnn
+    dataset: 50ep
+    epochs: 575
+    own_group: true
+    same_group: true
+    self_dropout: '0.15'
+  n_contributions: 21
+  n_punishments: 31
+  n_cross_val: 5
+  n_player: 8
+  n_groups: 2
+  data_file: experiments/2group_8agent_50ep.csv
+  model_name: graph
+  shuffle_features: [prev_contribution, prev_punishment]
+  basedir: .
+  output_dir: artifacts/artificial_humans/auto_contribution_selfdrop_15
+  model_args:
+    y_levels: 21
+    y_name: contribution
+    hidden_size: 20
+    add_rnn: True
+    add_edge_model: True
+    add_global_model: False
+    x_encoding:
+      - name: prev_contribution
+        n_levels: 21
+        encoding: numeric
+      - name: prev_punishment
+        n_levels: 31
+        encoding: numeric
+      - name: own_grp_prev_mean_contr
+        etype: float
+        norm: 20
+    edge_encoding:
+      - name: same_group
+        etype: bool
+  optimizer_args:
+    lr: 3.e-4
+    weight_decay: 1.e-5
+  train_args:
+    epochs: 575
+    batch_size: 4
+    clamp_grad: 1
+    eval_period: 50
+    l1_entropy: 0
+    input_dropout:
+      prev_contribution: 0.15
+  device: cuda
+  autoregression: False

--- a/configs/training/artificial_humans/contribution/auto_selfdrop_30.yml
+++ b/configs/training/artificial_humans/contribution/auto_selfdrop_30.yml
@@ -1,0 +1,72 @@
+description: >-
+  Autoresearch experiment contribution-self-history-dropout: the M4 feature
+  set (#114: own_grp_prev_mean_contr node feature + same_group edge feature)
+  trained with training-time input dropout on prev_contribution (p=0.30).
+  Hypothesis: the GNN anchors on its own previous contribution and ignores
+  the peer signal even when handed it (PR #116: peer beta +0.03 vs human
+  +0.25); stochastically masking the self-anchor during training forces the
+  conditional distribution to load on group context. Targets RCA/RCD.
+  Identical data / CV / seed / epochs to the M4 arm; separate output_dir.
+exec:
+  command: python -m aimanager train-ah {job_file}
+  script_name: run_training
+  data_dir: artifacts
+  temp_dir: .log
+  cores: 4
+  memory: 8
+params_only: true
+params:
+  fraction_training: 1.0
+  seed: 38381
+  mask_name: contribution_valid
+  experiment_names: [ah_group_switching]
+  labels:
+    architecture: node+edge+rnn
+    dataset: 50ep
+    epochs: 575
+    own_group: true
+    same_group: true
+    self_dropout: '0.30'
+  n_contributions: 21
+  n_punishments: 31
+  n_cross_val: 5
+  n_player: 8
+  n_groups: 2
+  data_file: experiments/2group_8agent_50ep.csv
+  model_name: graph
+  shuffle_features: [prev_contribution, prev_punishment]
+  basedir: .
+  output_dir: artifacts/artificial_humans/auto_contribution_selfdrop_30
+  model_args:
+    y_levels: 21
+    y_name: contribution
+    hidden_size: 20
+    add_rnn: True
+    add_edge_model: True
+    add_global_model: False
+    x_encoding:
+      - name: prev_contribution
+        n_levels: 21
+        encoding: numeric
+      - name: prev_punishment
+        n_levels: 31
+        encoding: numeric
+      - name: own_grp_prev_mean_contr
+        etype: float
+        norm: 20
+    edge_encoding:
+      - name: same_group
+        etype: bool
+  optimizer_args:
+    lr: 3.e-4
+    weight_decay: 1.e-5
+  train_args:
+    epochs: 575
+    batch_size: 4
+    clamp_grad: 1
+    eval_period: 50
+    l1_entropy: 0
+    input_dropout:
+      prev_contribution: 0.30
+  device: cuda
+  autoregression: False

--- a/configs/training/artificial_humans/contribution/auto_selfdrop_50.yml
+++ b/configs/training/artificial_humans/contribution/auto_selfdrop_50.yml
@@ -1,0 +1,72 @@
+description: >-
+  Autoresearch experiment contribution-self-history-dropout: the M4 feature
+  set (#114: own_grp_prev_mean_contr node feature + same_group edge feature)
+  trained with training-time input dropout on prev_contribution (p=0.50).
+  Hypothesis: the GNN anchors on its own previous contribution and ignores
+  the peer signal even when handed it (PR #116: peer beta +0.03 vs human
+  +0.25); stochastically masking the self-anchor during training forces the
+  conditional distribution to load on group context. Targets RCA/RCD.
+  Identical data / CV / seed / epochs to the M4 arm; separate output_dir.
+exec:
+  command: python -m aimanager train-ah {job_file}
+  script_name: run_training
+  data_dir: artifacts
+  temp_dir: .log
+  cores: 4
+  memory: 8
+params_only: true
+params:
+  fraction_training: 1.0
+  seed: 38381
+  mask_name: contribution_valid
+  experiment_names: [ah_group_switching]
+  labels:
+    architecture: node+edge+rnn
+    dataset: 50ep
+    epochs: 575
+    own_group: true
+    same_group: true
+    self_dropout: '0.50'
+  n_contributions: 21
+  n_punishments: 31
+  n_cross_val: 5
+  n_player: 8
+  n_groups: 2
+  data_file: experiments/2group_8agent_50ep.csv
+  model_name: graph
+  shuffle_features: [prev_contribution, prev_punishment]
+  basedir: .
+  output_dir: artifacts/artificial_humans/auto_contribution_selfdrop_50
+  model_args:
+    y_levels: 21
+    y_name: contribution
+    hidden_size: 20
+    add_rnn: True
+    add_edge_model: True
+    add_global_model: False
+    x_encoding:
+      - name: prev_contribution
+        n_levels: 21
+        encoding: numeric
+      - name: prev_punishment
+        n_levels: 31
+        encoding: numeric
+      - name: own_grp_prev_mean_contr
+        etype: float
+        norm: 20
+    edge_encoding:
+      - name: same_group
+        etype: bool
+  optimizer_args:
+    lr: 3.e-4
+    weight_decay: 1.e-5
+  train_args:
+    epochs: 575
+    batch_size: 4
+    clamp_grad: 1
+    eval_period: 50
+    l1_entropy: 0
+    input_dropout:
+      prev_contribution: 0.50
+  device: cuda
+  autoregression: False

--- a/notes/autoresearch_log/contribution-self-history-dropout.md
+++ b/notes/autoresearch_log/contribution-self-history-dropout.md
@@ -1,0 +1,133 @@
+# Experiment log: contribution-self-history-dropout
+
+## Declaration
+
+- **Slot:** contribution
+- **Base model:** GNN (node+edge+rnn, `group_switching_contribution_50ep`
+  lineage)
+- **Target rows:** RCA, RCD (declared collectively; CG is the hoped-for
+  side-effect, tracked but not a declared target)
+- **Deficit profile** (from `23_stack_sweep_updated/score_matrix.csv`,
+  contr=gnn contexts averaged over the other two slots): CG 9.65, RCA 2.85,
+  RCD 2.62, RCB 2.08. In the reference stack: CG 9.85, RCD 2.77, RCA 2.03.
+- **Hypothesis:** The GNN fails the reaction rows because behavioral cloning
+  lets it anchor on the agent's own previous contribution and ignore its
+  current group's level: PR #116 measured own-prior beta +0.74..0.78 vs human
+  +0.45, and new-group-peer beta +0.014..0.031 vs human +0.247 -- *even when
+  the leave-one-out own-group mean was handed to it as a feature* (the #114
+  M3/M4 arms). The peer signal is present but unused because self-history is
+  the cheaper predictor. Stochastically replacing `prev_contribution` with its
+  round-0 default during training removes the shortcut on a fraction of
+  agent-rounds and forces the conditional distribution to load on group
+  context -- the conditional-cooperation mechanism RCA (round-type reactions)
+  and RCD (switching pull) test. If group context drives the conditional mean
+  harder, group means also diverge more, which is the direction CG needs
+  (currently at the independence floor).
+- **Behavioral rationale (one sentence):** Humans are conditional cooperators
+  who adapt their contribution toward their current group's level, so forcing
+  the model off its self-anchor and onto the peer signal should move RCA and
+  RCD.
+- **Planned change (one change):** training-time input dropout on
+  `prev_contribution` (per agent-round Bernoulli, masked value = the feature's
+  round-0 default, training batches only -- simulation unchanged), trained on
+  the existing #114 M4 feature set (`own_grp_prev_mean_contr` node feature +
+  `same_group` edge feature, both merged on main). Dropout rate p in
+  {0.15, 0.3, 0.5}, selected by Stage-1 score (legal variant selection, §5).
+- **Verdict criteria:** Stage-1 in the reference stack (gnn switch x
+  lin_multinomial punisher, 23-family protocol). Keep iff RCA+RCD improve vs
+  RCA 2.03 / RCD 2.77, rows<=1 does not fall below 11/21, mean does not rise
+  above 1.76. Then Stage 2 (full 8-config sweep).
+
+## Results
+
+| date | change (one line) | stage | target scores | rows <= 1 | mean | verdict |
+|---|---|---|---|---|---|---|
+| 2026-08-11 | (baseline) reference stack, no change | 1 | RCA 2.035, RCD 2.772 | 11/21 | 1.760 | baseline |
+| 2026-08-11 | M4 features + prev_contribution dropout p=0.15 | 1 | RCA 2.772, RCD 2.336 | 12/21 | 1.585 | failed (RCA regressed) |
+| 2026-08-11 | M4 features + prev_contribution dropout p=0.30 | 1 | RCA 3.223, RCD 2.948 | 11/21 | 1.696 | failed (both targets regressed) |
+| 2026-08-11 | M4 features + prev_contribution dropout p=0.50 | 1 | RCA 4.142, RCD 2.791 | 11/21 | 1.690 | failed (RCA regressed) |
+| 2026-08-11 | control: M4 features, no dropout (p=0) | 1 | RCA 2.126, RCD 3.042 | 11/21 | 1.621 | control (not a candidate) |
+
+## Notes
+
+1. 2026-08-11: Reviewed prior art before declaring. #112 (same_group edge) and
+   #114 (own-group LOO mean) added the peer signal; PR #116 showed it barely
+   moves simulated behavior (peer beta +0.031 vs human +0.247) -- so a plain
+   artifact swap of the M3/M4 arms into the reference stack is unlikely to
+   clear the keep bar, and the experiment attacks the *use* of the signal, not
+   its availability. The M4 feature set is reused as the substrate because
+   dropout on the self-anchor only helps if an intact peer signal exists to
+   fall back on (the LOO mean excludes self, so it survives the masking).
+2. 2026-08-11: Implementation choices. Masked cells are set to the feature's
+   round-0 default (c_def via the `prev_`-to-base lookup), so "dropped" looks
+   exactly like the "no history yet" state the model already handles -- no new
+   out-of-range value, no train/sim distribution mismatch beyond the intended
+   one. Dropout applies to the shared `prev_contribution` tensor, so peers'
+   edge-view of a masked agent degrades too; accepted, because the intact
+   `own_grp_prev_mean_contr` (precomputed in preprocessing) remains the
+   reliable peer channel -- which is the channel we want the model to learn.
+   Epochs kept at the 575 budget for comparability; dropout regularizes, so
+   the known late-overfit risk shrinks rather than grows. Rates {0.15, 0.30,
+   0.50}, one config each (`configs/training/artificial_humans/contribution/
+   auto_selfdrop_{15,30,50}.yml`), Stage-1 sim configs
+   `configs/simulation/manager_testing/auto_2g8a_self_selfdrop{15,30,50}_contr_gnn_switch.yml`
+   (exact 23-family template, contribution path swapped).
+3. 2026-08-11: Trained (Raven jobs 29266994-96, ~8 min each, seed 38381,
+   5-fold + full). Fold-mean best test log-loss: M0 1.9892, M4 1.9899,
+   selfdrop 0.15 -> 2.0128, 0.30 -> 2.0605, 0.50 -> 2.1538. Log-loss
+   degrades monotonically with p, as expected -- the masking deliberately
+   discards the most predictive input on a fraction of cells. This is the
+   planned trade (likelihood for mechanism); whether it pays is decided by
+   the Stage-1 scores, not by log-loss. Stage-1 sims submitted (jobs
+   29267198/206/207).
+4. 2026-08-11: Stage-1 verdict: **the declared hypothesis failed** -- RCA got
+   *worse* in every variant, monotonically in p (2.035 -> 2.772 / 3.223 /
+   4.142), and RCB moved with it (1.928 -> ~2.65). Diagnosis: RCA/RCB measure
+   contribution *change*; weakening the self-anchor makes the model's own
+   level noisier, so its change distributions degrade -- the dropout attacks
+   the very statistic those rows condition on. RCD improved only at p=0.15
+   (2.772 -> 2.336) and not monotonically, so the switching-pull gain is not
+   clearly the mechanism either.
+5. 2026-08-11: The same runs surfaced an undeclared but robust effect in the
+   opposite family: the group-agreement rows improved across all three rates
+   -- CG 9.850 -> 5.961/6.940/5.899 (the reference stack's worst row, cut by
+   ~40%), SC 3.270 -> 2.767/2.720/2.402, CC 1.61 -> ~1.0, CE 1.33 -> ~1.0.
+   Mechanically consistent: agents that lean less on their own history and
+   more on shared group context act more alike, which is exactly the
+   between-participant correlation the independence-floor rows measure (§6 of
+   the guideline). At p=0.15 the stack metrics beat the baseline outright:
+   rows<=1 12/21 (vs 11), mean 1.585 (vs 1.760). Per the declaration this is
+   still a discard -- targets were RCA+RCD -- but it is the strongest CG
+   movement any contribution change has produced, and it did not come from
+   degrading the marginals much (CA 0.99, CD 0.87 at p=0.15, still at/near
+   the ceiling).
+6. 2026-08-11: Submitted a p=0 control (the #114 M4 model, same features, no
+   dropout; sim job under auto_2g8a_self_selfdrop00_contr_gnn_switch) to
+   attribute the CG/SC gains: if M4-without-dropout already shows them, the
+   features (not the dropout) are the cause; if not, the dropout is doing the
+   work. Result informs the follow-up declaration either way.
+7. 2026-08-11: Control result -- the attribution splits cleanly in two:
+   - **CG**: roughly half from the features (9.850 -> 7.587 at p=0), half
+     from the dropout (7.587 -> 5.961 at p=0.15). **SC**: entirely from the
+     features (3.270 -> 2.707 at p=0; flat in p until 0.50).
+   - **RCA/RCB degradation**: entirely from the dropout (p=0 sits at the
+     reference level: RCA 2.126, RCB 2.138). **RCD** is noise at Stage-1
+     resolution (3.042 / 2.336 / 2.948 / 2.791 across p -- spread ~0.7 with
+     no trend; treat RCD Stage-1 deltas < ~0.7 as unreadable).
+   - The M4 feature set alone (p=0) is a quiet across-the-board win the #114
+     evaluation missed because the eval suite did not exist yet: mean 1.760
+     -> 1.621, CG -2.26, SC -0.56, CC/CE/CA/SA all better or equal; worst
+     collateral RCB +0.21, RCD +0.27 (within RCD's noise). rows<=1 unchanged.
+8. 2026-08-11: **Final verdict: FAILED as declared** (targets RCA+RCD did not
+   improve; RCA regressed monotonically in p). Not reverting the code -- the
+   input-dropout mechanism is sound, config-gated, and off by default -- but
+   no candidate from this experiment goes to Stage 2 under this declaration.
+   **Recommended follow-up** (next loop iteration, own branch + declaration):
+   target **CG** with the M4 feature set, p in {0, 0.10, 0.15} -- at p=0.15
+   the stack metrics already beat the baseline outright (rows<=1 12/21, mean
+   1.585), and at p=0 nothing regresses at all. Disclose in that declaration
+   that the direction was discovered post-hoc in this experiment's runs (the
+   Stage-1 numbers here are its prior evidence, not its confirmation); the
+   §6 warning applies -- the RCA/RCB cost of nonzero p is real, so the
+   Kendall's-W discipline of Stage 2 should decide whether the trade holds
+   across contexts.

--- a/src/aimanager/artificial_humans/train.py
+++ b/src/aimanager/artificial_humans/train.py
@@ -36,6 +36,25 @@ def ablate_feature(data, feature_name):
     return data
 
 
+def dropout_input_features(data, dropout_rates, default_values):
+    # Training-time input dropout: per (episode, agent, round) cell, the
+    # feature is replaced by its round-0 default -- the same "no history"
+    # value shift() writes -- so the model must fall back on the remaining
+    # context instead of the masked signal. prev_-features inherit the base
+    # feature's default, matching how shift() fills their round 0.
+    data = {**data}
+    for feature, rate in dropout_rates.items():
+        base = feature[len("prev_") :] if feature.startswith("prev_") else feature
+        default = (
+            default_values[base] if base in default_values else default_values[feature]
+        )
+        val = data[feature].clone()
+        drop = th.rand(val.shape) < rate
+        val[drop] = int(default) if not val.is_floating_point() else float(default)
+        data[feature] = val
+    return data
+
+
 def batch_loader(data, batch_size):
     n = len(data["contribution"])
     all_idx = np.arange(n)
@@ -108,6 +127,7 @@ def main(config):
     train_args = config["train_args"]
     shuffle_features = config.get("shuffle_features", [])
     ablate_features = config.get("ablate_features", [])
+    input_dropout = train_args.get("input_dropout") or {}
     mask_name = config["mask_name"]
     job_id = config["job_id"]
     data_file = config["data_file"]
@@ -180,8 +200,11 @@ def main(config):
     conf_m_all = []
 
     for i, train_data, test_data in get_cross_validations(
-        data, n_cross_val, fraction_training,
-        holdout_fold=holdout_fold, group_key=pair_id,
+        data,
+        n_cross_val,
+        fraction_training,
+        holdout_fold=holdout_fold,
+        group_key=pair_id,
     ):
         model = AH_MODELS[model_name](
             default_values=default_values, autoregressive=autoregression, **model_args
@@ -227,6 +250,10 @@ def main(config):
                     mask_name,
                     default_values,
                 )
+                if input_dropout:
+                    b_data = dropout_input_features(
+                        b_data, input_dropout, default_values
+                    )
                 batch_data = model.encode(
                     b_data,
                     mask=mask_name,

--- a/src/aimanager/tests/test_input_dropout.py
+++ b/src/aimanager/tests/test_input_dropout.py
@@ -1,0 +1,58 @@
+"""Tests for training-time input dropout (dropout_input_features).
+
+Runs on Raven via scripts/remote_test.sh: importing the training module pulls
+in the AH model registry, which imports PyG.
+"""
+
+import torch as th
+
+from aimanager.artificial_humans.train import dropout_input_features
+
+DEFAULTS = {"contribution": 10.0, "own_grp_prev_mean_contr": 10.0}
+
+
+def make_data():
+    return {
+        "prev_contribution": th.full((6, 4, 24), 3, dtype=th.int64),
+        "own_grp_prev_mean_contr": th.full((6, 4, 24), 7.5, dtype=th.float),
+        "contribution": th.full((6, 4, 24), 5, dtype=th.int64),
+    }
+
+
+def test_rate_one_masks_everything_with_base_default():
+    data = make_data()
+    out = dropout_input_features(data, {"prev_contribution": 1.0}, DEFAULTS)
+    # prev_ features inherit the base feature's default, as shift() does
+    assert (out["prev_contribution"] == 10).all()
+    assert out["prev_contribution"].dtype == th.int64
+
+
+def test_rate_zero_is_identity():
+    data = make_data()
+    out = dropout_input_features(data, {"prev_contribution": 0.0}, DEFAULTS)
+    assert (out["prev_contribution"] == 3).all()
+
+
+def test_masked_fraction_matches_rate():
+    th.random.manual_seed(0)
+    data = {"prev_contribution": th.full((100, 8, 24), 3, dtype=th.int64)}
+    out = dropout_input_features(data, {"prev_contribution": 0.3}, DEFAULTS)
+    frac = (out["prev_contribution"] == 10).float().mean().item()
+    assert abs(frac - 0.3) < 0.02
+
+
+def test_direct_feature_uses_own_default():
+    data = make_data()
+    out = dropout_input_features(data, {"own_grp_prev_mean_contr": 1.0}, DEFAULTS)
+    assert (out["own_grp_prev_mean_contr"] == 10.0).all()
+    assert out["own_grp_prev_mean_contr"].dtype == th.float
+
+
+def test_other_features_and_input_untouched():
+    data = make_data()
+    out = dropout_input_features(data, {"prev_contribution": 1.0}, DEFAULTS)
+    # untouched keys pass through
+    assert (out["contribution"] == 5).all()
+    assert (out["own_grp_prev_mean_contr"] == 7.5).all()
+    # the input dict and its tensors are not mutated
+    assert (data["prev_contribution"] == 3).all()


### PR DESCRIPTION
Autoresearch experiment on the contribution slot. Full log: `notes/autoresearch_log/contribution-self-history-dropout.md`.

## Hypothesis

The GNN contributor anchors on its own previous contribution and ignores its current group's level even when handed it as a feature (PR #116: own-prior β +0.74 vs human +0.45, peer β +0.03 vs +0.25). Planned change: training-time input dropout on `prev_contribution` (masked cells get the round-0 default) on the #114 M4 feature set (`own_grp_prev_mean_contr` + `same_group`), p ∈ {0.15, 0.30, 0.50}. Targets: **RCA (2.035)** and **RCD (2.772)**.

## Results

| date | change (one line) | stage | target scores | rows <= 1 | mean | verdict |
|---|---|---|---|---|---|---|
| 2026-08-11 | (baseline) reference stack, no change | 1 | RCA 2.035, RCD 2.772 | 11/21 | 1.760 | baseline |
| 2026-08-11 | M4 features + prev_contribution dropout p=0.15 | 1 | RCA 2.772, RCD 2.336 | 12/21 | 1.585 | failed (RCA regressed) |
| 2026-08-11 | M4 features + prev_contribution dropout p=0.30 | 1 | RCA 3.223, RCD 2.948 | 11/21 | 1.696 | failed (both targets regressed) |
| 2026-08-11 | M4 features + prev_contribution dropout p=0.50 | 1 | RCA 4.142, RCD 2.791 | 11/21 | 1.690 | failed (RCA regressed) |
| 2026-08-11 | control: M4 features, no dropout (p=0) | 1 | RCA 2.126, RCD 3.042 | 11/21 | 1.621 | control (not a candidate) |

Stage 2 not run — no candidate met the keep criteria. RCA worsened monotonically in p: the dropout makes the model's own level noisy, attacking the change statistic RCA/RCB condition on.

## Collateral

**+**
- **CG** 9.850 → 7.587 from the M4 features alone, → 5.961 with p=0.15 — the strongest movement on the stack's worst row to date; seeds a follow-up experiment declared at CG (log notes 7–8).
- **SC** 3.270 → 2.707, entirely from the M4 features (flat in p). Together with CG: the p=0 control shows the #114 feature set alone is a quiet win (mean 1.760 → 1.621) that predates the eval suite and was never scored.
- CC 1.606 → 0.995 at p=0.15 (the +1 ceiling row — at 0.995, too thin to trust without Stage 2).

**−**
- **RCB** 1.928 → ~2.65 at every nonzero p (moves with RCA; same change-statistic mechanism).
- Marginals degrade with p (CA 0.772 → 1.437, CD 0.650 → 1.269 at p=0.50) — the §6 anti-correlation trade in action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)