### PR TITLE
[FAIL] Contribution CG: within-round Gaussian-copula sampling (rho ~ 0.07, stopped at the preflight gate)

### DIFF
--- a/artifacts/artificial_humans/group_switching_contribution_50ep_cg_copula/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__cg_copula.copula.json
+++ b/artifacts/artificial_humans/group_switching_contribution_50ep_cg_copula/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__cg_copula.copula.json
@@ -1,0 +1,30 @@
+{
+  "copula_rho": 0.06958238086256316,
+  "copula_rho_se": 0.010418260898762315,
+  "copula_rho_ci": [
+    0.04592661278794028,
+    0.0854596547235886
+  ],
+  "copula_estimator": "pairwise_mle",
+  "copula_diag_pit": "randomized",
+  "copula_diag_pit_rho": 0.045726003288415626,
+  "copula_cell_key": "episode_round_agent_group",
+  "copula_data_file": "experiments/baseline/2group_8agent_50ep_bline_train.csv",
+  "copula_data_note": "create_torch_data on the full human file (training defaults), restricted to the 40 single-copy train episodes; teacher-forced marginals from the source model; rows where contribution_valid",
+  "copula_n_rows": 7457,
+  "copula_n_cells": 1608,
+  "copula_n_pairs": 15090,
+  "copula_n_episodes": 40,
+  "copula_roundtrip_max_bias": 0.009462259703284237,
+  "copula_preflight": {
+    "independent": 0.7837119164031583,
+    "copula": 0.7928150641319318,
+    "human": 0.8472681041593946
+  },
+  "copula_holdout_rho": 0.13423231991344123,
+  "source_model": "artifacts/artificial_humans/group_switching_contribution_50ep/model/architecture_node+edge+rnn__dataset_50ep__epochs_575.pt",
+  "model": "artifacts/artificial_humans/group_switching_contribution_50ep_cg_copula/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__cg_copula.pt",
+  "script": "scripts/artificial_humans/contribution_copula_rho.py",
+  "seed": 38381,
+  "date": "2026-08-12T14:38:01+00:00"
+}

--- a/artifacts/artificial_humans/group_switching_contribution_50ep_cg_copula/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__cg_copula.pt
+++ b/artifacts/artificial_humans/group_switching_contribution_50ep_cg_copula/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__cg_copula.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af5375f4653a000c5c33462619eb0369235a0a8a9789ceaf2181531f61477007
+size 20627

--- a/artifacts/artificial_humans/group_switching_contribution_50ep_own_group_same_group/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__own_group_True__same_group_True.pt
+++ b/artifacts/artificial_humans/group_switching_contribution_50ep_own_group_same_group/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__own_group_True__same_group_True.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dad7206fe203a80c3dd85a7e8f9c4645a831e587ed8ac89b487be2bdba17a01d
+size 20691

--- a/artifacts/artificial_humans/group_switching_contribution_50ep_own_group_same_group_cg_copula/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__own_group_True__same_group_True__cg_copula.copula.json
+++ b/artifacts/artificial_humans/group_switching_contribution_50ep_own_group_same_group_cg_copula/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__own_group_True__same_group_True__cg_copula.copula.json
@@ -1,0 +1,30 @@
+{
+  "copula_rho": 0.06339366830297524,
+  "copula_rho_se": 0.009183923512964265,
+  "copula_rho_ci": [
+    0.04373197762808294,
+    0.07824941347179236
+  ],
+  "copula_estimator": "pairwise_mle",
+  "copula_diag_pit": "randomized",
+  "copula_diag_pit_rho": 0.04253327976648625,
+  "copula_cell_key": "episode_round_agent_group",
+  "copula_data_file": "experiments/baseline/2group_8agent_50ep_bline_train.csv",
+  "copula_data_note": "create_torch_data on the full human file (training defaults), restricted to the 40 single-copy train episodes; teacher-forced marginals from the source model; rows where contribution_valid",
+  "copula_n_rows": 7457,
+  "copula_n_cells": 1608,
+  "copula_n_pairs": 15090,
+  "copula_n_episodes": 40,
+  "copula_roundtrip_max_bias": 0.008355831148281312,
+  "copula_preflight": {
+    "independent": 0.8016186566630281,
+    "copula": 0.80998791254259,
+    "human": 0.8472681041593946
+  },
+  "copula_holdout_rho": 0.12209883905254384,
+  "source_model": "artifacts/artificial_humans/group_switching_contribution_50ep_own_group_same_group/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__own_group_True__same_group_True.pt",
+  "model": "artifacts/artificial_humans/group_switching_contribution_50ep_own_group_same_group_cg_copula/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__own_group_True__same_group_True__cg_copula.pt",
+  "script": "scripts/artificial_humans/contribution_copula_rho.py",
+  "seed": 38381,
+  "date": "2026-08-12T14:39:45+00:00"
+}

--- a/artifacts/artificial_humans/group_switching_contribution_50ep_own_group_same_group_cg_copula/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__own_group_True__same_group_True__cg_copula.pt
+++ b/artifacts/artificial_humans/group_switching_contribution_50ep_own_group_same_group_cg_copula/model/architecture_node+edge+rnn__dataset_50ep__epochs_575__own_group_True__same_group_True__cg_copula.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abb8ff52a895164ea57621af4d4f514c43c3805b3cfa60aed3c854f380f6ebb2
+size 20627

--- a/notes/autoresearch_log/contribution-cg-copula.md
+++ b/notes/autoresearch_log/contribution-cg-copula.md
@@ -96,24 +96,24 @@ Slug: `cg_copula`.
       marginals intact; rho absent/0.0 bit-identical to legacy decode
       incl. RNG; save/load round-trips `copula_rho`; committed M0 loads
       at 0.0; init gate raises (protects switch + valid models).
-- [ ] 7. Calibration script
+- [x] 7. Calibration script
       `scripts/artificial_humans/contribution_copula_rho.py`
       (`--model IN.pt --out OUT.pt [--preflight] [--roundtrip]`), importing
       the #146 estimator machinery from
       `scripts/baselines/punishment_copula_rho.py` unmodified; installs the
       `torch_geometric.nn.meta` alias before `GraphNetwork.load` (D7).
-- [ ] 8. Calibration data: `create_torch_data` on the FULL human file (so
+- [x] 8. Calibration data: `create_torch_data` on the FULL human file (so
       defaults match training), then keep the 40 single-copy episodes of
       `experiments/baseline/2group_8agent_50ep_bline_train.csv`, taking the
       copy present in the train file (copy choice is not neutral — D5).
       Teacher-forced `predict_independent(sample=False)` probabilities,
       rows where `contribution_valid`, cells = (episode, round, agent_group).
-- [ ] 9. Estimator + gates: pairwise MLE (grid + Brent), cluster bootstrap
+- [x] 9. Estimator + gates: pairwise MLE (grid + Brent), cluster bootstrap
       SE/CI over 40 episodes, `--roundtrip` acceptance (max |bias| <= 0.03),
       randomized-PIT printed as attenuated diagnostic, test-split rho as
       out-of-sample check only, `--preflight` group-spread ratios
       (independent / copula / human) as go/no-go only (D9).
-- [ ] 10. Stamp rho into a copy of the artifact: `model.copula_rho = rho;
+- [x] 10. Stamp rho into a copy of the artifact: `model.copula_rho = rho;
       model.save(out)`; reload-assert logits bit-identical, rho
       round-trips, no other key changed. Arm A out:
       `artifacts/artificial_humans/group_switching_contribution_50ep_cg_copula/model/..._cg_copula.pt`.

--- a/notes/autoresearch_log/contribution-cg-copula.md
+++ b/notes/autoresearch_log/contribution-cg-copula.md
@@ -51,7 +51,97 @@
 
 ## 2. Plan
 
-(to be filled by the validated planner step list)
+Validated by the orchestrator 2026-08-12 (targets per §2, legality per §5,
+frozen surface per §8; planner discrepancies D1–D9 recorded in Notes).
+Slug: `cg_copula`.
+
+- [ ] 1. (Raven) Cluster preflight: `squeue -u certuer` for parallel
+      PENDING jobs; confirm M0 `.pt` exists remotely; check whether the M4
+      `.pt` from PR #144 still exists on Raven (metrics were fetched, model
+      never was — D6); confirm scipy importable in the remote `.venv`.
+- [ ] 2. (Raven) Start the M4 retrain (long pole) unless D6 found it:
+      `scripts/train_cluster.sh ah configs/training/artificial_humans/contribution/group_switching_contribution_50ep_own_group_same_group.yml`
+      (unchanged config, seed-pinned). Poll while later steps proceed.
+- [ ] 3. New pure-torch module `src/aimanager/generic/copula.py` (no PyG
+      import, locally testable): `sample_levels_copula(proba, cells, rho)`
+      with the #146 sampler conventions — exactly 2N float64 draws per call
+      (`zs` then `eps`), latent from each cell's first member,
+      `u = ndtr(sqrt(rho) z + sqrt(1-rho) eps)`, discrete-quantile
+      inversion via searchsorted on the cumsum, clamp to [0, K-1].
+- [ ] 4. Wire into `GraphNetwork` (`src/aimanager/generic/graph.py`),
+      contribution draw only: `copula_rho=0.0` in `__init__` (assert
+      0 <= rho < 1; rho > 0 only with `y_name == "contribution"`), append
+      to `to_save`; optional `cells=None` through `predict_encoded`;
+      `predict_independent` builds cells from `data["agent_group"]`.
+      `predict_autoreg`, `encode`, `forward`, `encoder.decode` byte-
+      identical; legacy `.pt` loads default to 0.0 (exact pre-change RNG).
+- [ ] 5. Local unit tests `tests/copula/test_contribution_copula.py` (pure
+      torch): bin-edge inversion; marginal preservation vs independent
+      draws; within-cell corr > 0, cross-cell ~ 0; determinism;
+      composition-stable RNG consumption; parity vs
+      `LinearAHAdapter._sample_levels_copula` on the same P/groups/seed.
+- [ ] 6. (Raven) GNN wiring tests
+      `src/aimanager/tests/test_contribution_copula_gnn.py` via
+      `remote_test.sh`: toy GraphNetwork induces within-group corr with
+      marginals intact; rho absent/0.0 bit-identical to legacy decode
+      incl. RNG; save/load round-trips `copula_rho`; committed M0 loads
+      at 0.0; init gate raises (protects switch + valid models).
+- [ ] 7. Calibration script
+      `scripts/artificial_humans/contribution_copula_rho.py`
+      (`--model IN.pt --out OUT.pt [--preflight] [--roundtrip]`), importing
+      the #146 estimator machinery from
+      `scripts/baselines/punishment_copula_rho.py` unmodified; installs the
+      `torch_geometric.nn.meta` alias before `GraphNetwork.load` (D7).
+- [ ] 8. Calibration data: `create_torch_data` on the FULL human file (so
+      defaults match training), then keep the 40 single-copy episodes of
+      `experiments/baseline/2group_8agent_50ep_bline_train.csv`, taking the
+      copy present in the train file (copy choice is not neutral — D5).
+      Teacher-forced `predict_independent(sample=False)` probabilities,
+      rows where `contribution_valid`, cells = (episode, round, agent_group).
+- [ ] 9. Estimator + gates: pairwise MLE (grid + Brent), cluster bootstrap
+      SE/CI over 40 episodes, `--roundtrip` acceptance (max |bias| <= 0.03),
+      randomized-PIT printed as attenuated diagnostic, test-split rho as
+      out-of-sample check only, `--preflight` group-spread ratios
+      (independent / copula / human) as go/no-go only (D9).
+- [ ] 10. Stamp rho into a copy of the artifact: `model.copula_rho = rho;
+      model.save(out)`; reload-assert logits bit-identical, rho
+      round-trips, no other key changed. Arm A out:
+      `artifacts/artificial_humans/group_switching_contribution_50ep_cg_copula/model/..._cg_copula.pt`.
+- [ ] 11. (Raven) Run arm-A calibration (+preflight +roundtrip). Escalate
+      and stop before any sim if rho CI touches 0, round-trip fails, or
+      preflight barely moves the ratio. Fetch + commit the `.pt`; log rho,
+      SE, CI, round-trip, preflight unrounded.
+- [ ] 12. (Raven) M4 arrived: fetch + commit; run arm-B calibration the
+      same way (own rho, never reuse arm A's); same gates; log.
+- [ ] 13. Stage-1 configs (single `lin_multinomial_self` pairing, protocol
+      byte-identical):
+      `23_2g8a_cg_copula_m0_self_gnn_copula_contr_gnn_switch.yml` and
+      `23_2g8a_cg_copula_m4_self_gnnm4_copula_contr_gnn_switch.yml`.
+- [ ] 14. (Raven) squeue guard, then `simulate_cluster.sh` both arms;
+      verify remote artifact paths before submitting; confirm
+      `per_round.parquet`.
+- [ ] 15. `fetch_cluster.sh` + `python -m aimanager evaluate` both arms;
+      read unrounded scores.
+- [ ] 16. Arm selection by Stage-1 CG subject to guards. Keep iff
+      CG < 9.850 AND rows<=1 >= 11 AND mean <= 1.759557; RC/CA/CD rows
+      materially moving on arm A signals a sampler bug (arm B compares
+      against #144's p=0 control: CG 7.587, 11/21, 1.621).
+- [ ] 17. Band decision: upgrade requires CG < 5 in the reference stack.
+      Kept-but-within-band or gate-fail -> Notes + `[FAIL]` PR (skip
+      Stage 2, it cannot become a success).
+- [ ] 18. (If Stage 2) add the winning contr token to `CONTR_ORDER` and
+      `CONTR_MARKERS` in `scripts/data_analysis/evaluation_sweep.py`
+      (analysis layer; D2 — there is no CONTR_COLORS).
+- [ ] 19. Stage-2 configs: TWO configs (D1), full four-punisher pairing
+      block, gnn-switch and lin-switch variants:
+      `23_2g8a_cg_copula_self_<label>_contr_{gnn,lin}_switch.yml`
+      = 8 contexts.
+- [ ] 20. (Raven) Simulate, fetch, evaluate both; sweep old 8 reference
+      dirs + 2 new into `23_stack_sweep_cg_copula`; confirm slot claim on
+      CG across all 8 contexts, guards hold, band upgrade survives
+      (unrounded scores.csv for boundary calls).
+- [ ] 21. Complete this log; PR `[SUCCESS]`/`[FAIL]`, body Hypothesis /
+      Results / Collateral; commits map to steps.
 
 ## 3. Results
 
@@ -71,3 +161,29 @@
    punisher-severity-copula (merged). Slug `cg_copula` chosen so config and
    output-dir names cannot collide; per the #146 incident, check
    `squeue -u certuer` for PENDING jobs before any cluster rsync.
+3. Planner discrepancies, orchestrator rulings: (D1) contribution Stage 2
+   is 2 configs x 4 punisher pairings = 8 contexts, not 8 configs — plan
+   step 19 reflects it. (D2) `evaluation_sweep.py` has CONTR_ORDER +
+   CONTR_MARKERS, no CONTR_COLORS. (D3) encoder/graph import PyG at module
+   level: calibration, rho stamping, and all GNN-level tests run on Raven;
+   only the standalone sampler module tests locally. (D4) the GNN trained
+   on all 100 flip-doubled episodes, so rho on the 40-episode baseline
+   train split is holdout-closing convention, not out-of-sample w.r.t. the
+   marginals — no out-of-fold predictions exist to do better; disclosed
+   here. (D5) flip-doubling lives in the CSV and M0 conditions on
+   agent_group, so the two copies of a game give different marginals —
+   calibration takes exactly the copy present in the train file. (D6) the
+   M4 `.pt` may still exist on Raven from PR #144 — check before
+   retraining. (D7) `copula_rho` rides in the `.pt` via `__init__` +
+   `to_save`; legacy artifacts splat to the 0.0 default; re-saving needs
+   the `torch_geometric.nn.meta` alias to load legacy pickles. (D8) latent
+   keyed per `agent_group` within one predict call (one call covers both
+   groups), same resolution as #146's D1. (D9) the preflight group-spread
+   ratio is CG's own statistic: go/no-go readout only, rho never tuned to
+   it.
+4. Planner risk assessment, accepted: the copula is a within-round,
+   round-independent shock while CG rewards persistent between-group
+   divergence, and marginals mean-revert through prev_contribution and the
+   RNN — closing 0.59 -> 0.85 at group size 4 would imply latent rho ~ 0.6,
+   likely outside the honest MLE's CI. Realistic failure mode is
+   kept-but-within-band; the step-11 preflight is the cheap early read.

--- a/notes/autoresearch_log/contribution-cg-copula.md
+++ b/notes/autoresearch_log/contribution-cg-copula.md
@@ -1,0 +1,73 @@
+# Autoresearch log: contribution-cg-copula
+
+## 1. Declaration
+
+- **Slot:** contribution
+- **Base model:** `gnn` (M0 reference,
+  `artifacts/artificial_humans/group_switching_contribution_50ep/model/architecture_node+edge+rnn__dataset_50ep__epochs_575.pt`).
+- **Target rows:** CG — reference stack 9.850; slot average 9.651; fully
+  concordant (9.10–10.14 in all 8 contexts), the stack's worst row. Band
+  > 5; success requires CG < 5 (into 2–5) in the reference stack, confirmed
+  by Stage 2.
+- **Hypothesis:** members of a group co-move because they see the same
+  situation and because the model's error about their shared situation is
+  common to all four — but the simulation draws every agent's contribution
+  independently from its own marginal (`th.multinomial` per agent in
+  `encoder.decode`), throwing the correlated component away and pinning the
+  group-mean spread near the independence floor (human spread ratio 0.85 vs
+  sim 0.59; the motivating analysis on PR #140). PR #147 showed forcing
+  peer-conditioning via self-history dropout moves CG (9.85 → 5.96) but
+  pays with the individual change statistics (RCA/RCB worse in 8/8) — its
+  closing note names this experiment's family: restore the group-level
+  co-movement *without noising the self-level*. A within-round exchangeable
+  Gaussian copula over the group's four predicted contribution marginals —
+  one shared standard-normal latent per (group, round), mixed with
+  per-agent noise at weight rho, pushed through each agent's own predicted
+  CDF — preserves every individual marginal exactly (so RCA/RCB/CA/CD are
+  structurally protected) while restoring the shared-error correlation the
+  independent sampler destroys. The mechanism and the honest rho estimator
+  (pairwise-likelihood MLE given the model's own predicted probabilities,
+  train split only) are proven on the punisher slot (PR #146, PD 2.93 →
+  1.53, merged); contribution's 21 classes are less lumpy than
+  punishment's, so the estimator operates on friendlier ground.
+- **Planned change:** copula sampling at the GNN contributor's free-running
+  draw. Legal variant selection by Stage-1 CG under the stack guards (§5):
+  (a) copula on the M0 marginals, (b) copula on the M4 peer-feature
+  marginals (`own_grp_prev_mean_contr` + `same_group`, no dropout — PR
+  #144's p=0 control: CG 7.587, rows 11/21, mean 1.621, guards clean; its
+  `.pt` was never committed, so this arm is a retrain of
+  `group_switching_contribution_50ep_own_group_same_group`). Each arm's rho
+  is estimated against its own marginals. Sampling-layer change only; no
+  loss, architecture, or evaluation-suite change.
+- **Stack guards (must not regress):** rows <= 1 baseline 11/21; mean
+  baseline 1.76 (reference stack `gnn x gnn x lin_multinomial`).
+- **Prior art consulted:** PR #144 [FAIL] (dropout regresses RCA), PR #147
+  [FAIL] (kept but no band upgrade; RCA/RCB collateral), PR #146 [SUCCESS]
+  (copula mechanism + estimator), PR #140 comment (sampler-vs-model
+  decomposition: for contribution ~1/6 of the co-movement gap is
+  sampler-bound on a *well-conditioned* model — the free-running GNN
+  under-uses state, so its residual shared error, which the copula carries,
+  is larger; the calibration step measures it before any cluster run).
+
+## 2. Plan
+
+(to be filled by the validated planner step list)
+
+## 3. Results
+
+| date | change (one line) | stage | target scores | rows <= 1 | mean | verdict |
+|---|---|---|---|---|---|---|
+| 2026-08-12 | (baseline) reference stack, no change | 1 | CG 9.850 | 11/21 | 1.760 | baseline |
+
+## 4. Notes
+
+1. Deficit profile from `23_stack_sweep_updated/score_matrix.csv`: CG is the
+   gnn contributor's only row that is both worst-in-stack and fully
+   concordant (9.10–10.14 across all 8 contexts). RCA 2.85 / RCD 2.63 /
+   RCB 2.08 are concordant secondaries; PA/PC/RPB spike only in
+   gaussian/ridge punisher contexts (punisher-attributable).
+2. Parallel experiments checked at branch creation: contribution-prev-onehot
+   (cat base, RCA — no overlap), switch-herding-copula (switch slot),
+   punisher-severity-copula (merged). Slug `cg_copula` chosen so config and
+   output-dir names cannot collide; per the #146 incident, check
+   `squeue -u certuer` for PENDING jobs before any cluster rsync.

--- a/notes/autoresearch_log/contribution-cg-copula.md
+++ b/notes/autoresearch_log/contribution-cg-copula.md
@@ -85,7 +85,7 @@ Slug: `cg_copula`.
       `predict_independent` builds cells from `data["agent_group"]`.
       `predict_autoreg`, `encode`, `forward`, `encoder.decode` byte-
       identical; legacy `.pt` loads default to 0.0 (exact pre-change RNG).
-- [ ] 5. Local unit tests `tests/copula/test_contribution_copula.py` (pure
+- [x] 5. Local unit tests `tests/copula/test_contribution_copula.py` (pure
       torch): bin-edge inversion; marginal preservation vs independent
       draws; within-cell corr > 0, cross-cell ~ 0; determinism;
       composition-stable RNG consumption; parity vs

--- a/notes/autoresearch_log/contribution-cg-copula.md
+++ b/notes/autoresearch_log/contribution-cg-copula.md
@@ -117,12 +117,14 @@ Slug: `cg_copula`.
       model.save(out)`; reload-assert logits bit-identical, rho
       round-trips, no other key changed. Arm A out:
       `artifacts/artificial_humans/group_switching_contribution_50ep_cg_copula/model/..._cg_copula.pt`.
-- [ ] 11. (Raven) Run arm-A calibration (+preflight +roundtrip). Escalate
-      and stop before any sim if rho CI touches 0, round-trip fails, or
-      preflight barely moves the ratio. Fetch + commit the `.pt`; log rho,
-      SE, CI, round-trip, preflight unrounded.
-- [ ] 12. (Raven) M4 arrived: fetch + commit; run arm-B calibration the
-      same way (own rho, never reuse arm A's); same gates; log.
+- [x] 11. (Raven) Run arm-A calibration (+preflight +roundtrip) — amended
+      to a SLURM CPU job (`calibrate_copula.slurm`; maintainer feedback:
+      no compute on login nodes). Estimator gates passed but preflight
+      moved the ratio only ~14% of the gap -> escalated per this step;
+      maintainer ruled STOP after calibration (Notes 8). Artifact +
+      sidecar fetched and committed; numbers in Notes 6.
+- [x] 12. (Raven) Arm-B calibration ran the same way (own rho); numbers
+      in Notes 9. The M4 `.pt` itself was already fetched at step 2.
 - [ ] 13. Stage-1 configs (single `lin_multinomial_self` pairing pointing
       at the severity-copula joblib — the re-baselined reference punisher,
       Notes 5 — protocol byte-identical):
@@ -152,8 +154,12 @@ Slug: `cg_copula`.
       dirs + 2 new into `23_stack_sweep_cg_copula`; confirm slot claim on
       CG across all 8 contexts, guards hold, band upgrade survives
       (unrounded scores.csv for boundary calls).
-- [ ] 21. Complete this log; PR `[SUCCESS]`/`[FAIL]`, body Hypothesis /
-      Results / Collateral; commits map to steps.
+- [x] 21. Complete this log; PR `[FAIL]`, body Hypothesis / Results /
+      Collateral; commits map to steps.
+
+Steps 13-20 not run: the maintainer stopped the experiment after
+calibration (step-11 escalation, Notes 8) — no Stage-1 simulation, no
+Stage 2.
 
 ## 3. Results
 
@@ -161,6 +167,8 @@ Slug: `cg_copula`.
 |---|---|---|---|---|---|---|
 | 2026-08-12 | (baseline) reference stack, old multinomial punisher | 1 | CG 9.850 | 11/21 | 1.760 | superseded baseline |
 | 2026-08-12 | (baseline) reference stack, severity-copula punisher (#146 Stage-1 run) | 1 | CG 9.808514 | 10/21 | 1.687998 | baseline (Notes 5) |
+| 2026-08-12 | arm A: M0 + copula, rho=0.06958238086256316 (calibration only, job 29302549) | — | preflight spread ratio 0.7837 -> 0.7928 (human 0.8473) | no sim | no sim | stopped at step-11 gate (Notes 6, 8) |
+| 2026-08-12 | arm B: M4 + copula, rho=0.06339366830297524 (calibration only, job 29302550) | — | preflight spread ratio 0.8016 -> 0.8100 (human 0.8473) | no sim | no sim | stopped at step-11 gate (Notes 8, 9) |
 
 ## 4. Notes
 
@@ -210,3 +218,50 @@ Slug: `cg_copula`.
    adjudicated as noise), mean 1.687998. Target unaffected (CG 9.85 →
    9.81); Stage-1 configs will point `lin_multinomial` at the copula
    joblib.
+6. Arm A (M0) calibration, SLURM job 29302549 (first submission 29302450
+   died only on an over-strict re-save assert — the June artifact predates
+   `edge_encoding` in `GraphNetwork.save`'s key list; fix committed,
+   064c442): **rho_hat = 0.06958238086256316**, cluster-bootstrap SE
+   0.010418260898762315, 95% CI [0.04592661278794028, 0.0854596547235886];
+   round-trip gate PASS (max |bias| 0.009462259703284237, tolerance 0.03);
+   PIT attenuated diagnostic 0.0457; holdout (10 episodes, check only)
+   0.13423231991344123. Preflight (50 repeats): independent
+   0.7837119164031583, copula 0.7928150641319318, human 0.8472681041593946
+   — the copula closes ~14% of the teacher-forced gap, matching PR #140's
+   ~1/6 sampler share almost exactly.
+7. The decisive structural finding: **teacher-forced, M0's independent
+   group-spread ratio is already 0.784** vs the free-running sim's ~0.59.
+   The CG deficit is therefore overwhelmingly free-running state-tracking
+   loss, not within-round sampling — the model tracks the group fine when
+   fed real histories and drifts off only under its own dynamics. Also:
+   residual dependence grows over the game (MLE by round thirds
+   0.0345 / 0.0736 / 0.1187) — late-game norm lock-in that a constant
+   within-round rho cannot represent.
+8. Step-11 escalation and maintainer ruling: rho clearly > 0 and gates
+   passed, but the preflight movement (+0.009 of a 0.064 gap) makes a CG
+   band upgrade (9.81 -> < 5) implausible; free-running amplification via
+   prev_contribution feedback was the one unknown a ~3-GPU-min Stage-1 sim
+   would have measured. Maintainer ruled: **stop after calibration, no
+   sims** — experiment closes `[FAIL]` on preflight evidence. Both stamped
+   artifacts + provenance sidecars committed for any future reuse (the
+   sampler, wiring, and tests are all merged-quality and stay on the
+   branch).
+9. Arm B (M4) calibration, job 29302550: rho_hat = 0.06339366830297524,
+   SE 0.009183923512964265, CI [0.04373197762808294, 0.07824941347179236];
+   gate PASS (max |bias| 0.008355831148281312); holdout
+   0.12209883905254384. Preflight: independent 0.8016186566630281, copula
+   0.80998791254259, human 0.8472681041593946. Confirms the mechanism:
+   M4's peer features raise the teacher-forced independent ratio (0.802 vs
+   M0's 0.784) and absorb a little of the residual dependence (rho 0.063
+   vs 0.070) — better conditioning, less left for the sampler.
+10. Directions this leaves for the next agent, ranked by what the data
+   here say: (i) attack free-running state tracking directly — the 0.784
+   vs 0.59 gap is the whole game; scheduled sampling / free-running-aware
+   training or stronger group-state features evaluated in free-run, not
+   teacher-forced fit; (ii) an episode-persistent shared latent (PR #140
+   Option 1, ensemble-per-episode) — unlike the within-round shock it
+   compounds, and the human early-late segregation correlation (0.38 vs
+   sim 0.03) is direct evidence for a persistent component; (iii) a
+   round-growing rho (0.035 -> 0.119 by thirds) is real but second-order
+   next to (i). A plain constant within-round copula on the contribution
+   slot is now measured and closed: do not retry it.

--- a/notes/autoresearch_log/contribution-cg-copula.md
+++ b/notes/autoresearch_log/contribution-cg-copula.md
@@ -90,7 +90,7 @@ Slug: `cg_copula`.
       draws; within-cell corr > 0, cross-cell ~ 0; determinism;
       composition-stable RNG consumption; parity vs
       `LinearAHAdapter._sample_levels_copula` on the same P/groups/seed.
-- [ ] 6. (Raven) GNN wiring tests
+- [x] 6. (Raven) GNN wiring tests
       `src/aimanager/tests/test_contribution_copula_gnn.py` via
       `remote_test.sh`: toy GraphNetwork induces within-group corr with
       marginals intact; rho absent/0.0 bit-identical to legacy decode

--- a/notes/autoresearch_log/contribution-cg-copula.md
+++ b/notes/autoresearch_log/contribution-cg-copula.md
@@ -41,6 +41,13 @@
   loss, architecture, or evaluation-suite change.
 - **Stack guards (must not regress):** rows <= 1 baseline 11/21; mean
   baseline 1.76 (reference stack `gnn x gnn x lin_multinomial`).
+  **Re-baselined 2026-08-12 (maintainer ruling, Notes 5):** the reference
+  punisher is now the severity-copula multinomial bundle
+  (`artifacts/baselines/punishment_multinomial_severity_copula.joblib`,
+  PR #146, same `lin_multinomial` slot). New reference cell = #146's
+  Stage-1 run (`23_2g8a_severity_copula_self_gnn_contr_gnn_switch`):
+  **CG 9.808514; rows <= 1 = 10/21; mean 1.687998** — these replace
+  9.850 / 11 / 1.759557 everywhere in the plan's gates.
 - **Prior art consulted:** PR #144 [FAIL] (dropout regresses RCA), PR #147
   [FAIL] (kept but no band upgrade; RCA/RCB collateral), PR #146 [SUCCESS]
   (copula mechanism + estimator), PR #140 comment (sampler-vs-model
@@ -71,7 +78,7 @@ Slug: `cg_copula`.
       (`zs` then `eps`), latent from each cell's first member,
       `u = ndtr(sqrt(rho) z + sqrt(1-rho) eps)`, discrete-quantile
       inversion via searchsorted on the cumsum, clamp to [0, K-1].
-- [ ] 4. Wire into `GraphNetwork` (`src/aimanager/generic/graph.py`),
+- [x] 4. Wire into `GraphNetwork` (`src/aimanager/generic/graph.py`),
       contribution draw only: `copula_rho=0.0` in `__init__` (assert
       0 <= rho < 1; rho > 0 only with `y_name == "contribution"`), append
       to `to_save`; optional `cells=None` through `predict_encoded`;
@@ -116,8 +123,9 @@ Slug: `cg_copula`.
       SE, CI, round-trip, preflight unrounded.
 - [ ] 12. (Raven) M4 arrived: fetch + commit; run arm-B calibration the
       same way (own rho, never reuse arm A's); same gates; log.
-- [ ] 13. Stage-1 configs (single `lin_multinomial_self` pairing, protocol
-      byte-identical):
+- [ ] 13. Stage-1 configs (single `lin_multinomial_self` pairing pointing
+      at the severity-copula joblib — the re-baselined reference punisher,
+      Notes 5 — protocol byte-identical):
       `23_2g8a_cg_copula_m0_self_gnn_copula_contr_gnn_switch.yml` and
       `23_2g8a_cg_copula_m4_self_gnnm4_copula_contr_gnn_switch.yml`.
 - [ ] 14. (Raven) squeue guard, then `simulate_cluster.sh` both arms;
@@ -126,7 +134,8 @@ Slug: `cg_copula`.
 - [ ] 15. `fetch_cluster.sh` + `python -m aimanager evaluate` both arms;
       read unrounded scores.
 - [ ] 16. Arm selection by Stage-1 CG subject to guards. Keep iff
-      CG < 9.850 AND rows<=1 >= 11 AND mean <= 1.759557; RC/CA/CD rows
+      CG < 9.808514 AND rows<=1 >= 10 AND mean <= 1.687998 (re-baselined,
+      Notes 5); RC/CA/CD rows
       materially moving on arm A signals a sampler bug (arm B compares
       against #144's p=0 control: CG 7.587, 11/21, 1.621).
 - [ ] 17. Band decision: upgrade requires CG < 5 in the reference stack.
@@ -150,7 +159,8 @@ Slug: `cg_copula`.
 
 | date | change (one line) | stage | target scores | rows <= 1 | mean | verdict |
 |---|---|---|---|---|---|---|
-| 2026-08-12 | (baseline) reference stack, no change | 1 | CG 9.850 | 11/21 | 1.760 | baseline |
+| 2026-08-12 | (baseline) reference stack, old multinomial punisher | 1 | CG 9.850 | 11/21 | 1.760 | superseded baseline |
+| 2026-08-12 | (baseline) reference stack, severity-copula punisher (#146 Stage-1 run) | 1 | CG 9.808514 | 10/21 | 1.687998 | baseline (Notes 5) |
 
 ## 4. Notes
 

--- a/notes/autoresearch_log/contribution-cg-copula.md
+++ b/notes/autoresearch_log/contribution-cg-copula.md
@@ -55,14 +55,17 @@ Validated by the orchestrator 2026-08-12 (targets per §2, legality per §5,
 frozen surface per §8; planner discrepancies D1–D9 recorded in Notes).
 Slug: `cg_copula`.
 
-- [ ] 1. (Raven) Cluster preflight: `squeue -u certuer` for parallel
+- [x] 1. (Raven) Cluster preflight: `squeue -u certuer` for parallel
       PENDING jobs; confirm M0 `.pt` exists remotely; check whether the M4
       `.pt` from PR #144 still exists on Raven (metrics were fetched, model
       never was — D6); confirm scipy importable in the remote `.venv`.
-- [ ] 2. (Raven) Start the M4 retrain (long pole) unless D6 found it:
+- [x] 2. (Raven) ~~Start the M4 retrain (long pole)~~ D6 confirmed: the M4
+      `.pt` exists on Raven (mtime Jul 1 — the seed-pinned product of the
+      unchanged config); fetched and committed instead of retraining.
+      Original step:
       `scripts/train_cluster.sh ah configs/training/artificial_humans/contribution/group_switching_contribution_50ep_own_group_same_group.yml`
       (unchanged config, seed-pinned). Poll while later steps proceed.
-- [ ] 3. New pure-torch module `src/aimanager/generic/copula.py` (no PyG
+- [x] 3. New pure-torch module `src/aimanager/generic/copula.py` (no PyG
       import, locally testable): `sample_levels_copula(proba, cells, rho)`
       with the #146 sampler conventions — exactly 2N float64 draws per call
       (`zs` then `eps`), latent from each cell's first member,

--- a/notes/autoresearch_log/contribution-cg-copula.md
+++ b/notes/autoresearch_log/contribution-cg-copula.md
@@ -200,3 +200,13 @@ Slug: `cg_copula`.
    RNN — closing 0.59 -> 0.85 at group size 4 would imply latent rho ~ 0.6,
    likely outside the honest MLE's CI. Realistic failure mode is
    kept-but-within-band; the step-11 preflight is the cheap early read.
+5. Maintainer ruling 2026-08-12 (mid-experiment, before any Stage-1 config
+   existed): the reference punisher is now the severity-copula multinomial
+   bundle from PR #146 — same `lin_multinomial` slot, not a separate
+   option; the maintainer updates `notes/autoresearch.md` themselves.
+   Experiment re-baselined to #146's Stage-1 cell
+   (`23_2g8a_severity_copula_self_gnn_contr_gnn_switch`): CG 9.808514,
+   rows <= 1 = 10/21 (RSA 1.001009 — the razor-edge row #146's Stage 2
+   adjudicated as noise), mean 1.687998. Target unaffected (CG 9.85 →
+   9.81); Stage-1 configs will point `lin_multinomial` at the copula
+   joblib.

--- a/scripts/artificial_humans/calibrate_copula.slurm
+++ b/scripts/artificial_humans/calibrate_copula.slurm
@@ -1,0 +1,23 @@
+#!/bin/bash -l
+#
+# CPU-only SLURM job for the contribution copula calibration.
+# Usage: sbatch scripts/artificial_humans/calibrate_copula.slurm <model.pt> <out.pt>
+#
+#SBATCH --chdir=.
+#SBATCH --output=temp/calibrate_copula_%j.log
+#SBATCH --error=temp/calibrate_copula_%j.log
+#SBATCH --job-name=cg_copula_rho
+#
+#SBATCH --nodes=1
+#SBATCH --tasks-per-node=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=16GB
+#
+#SBATCH --time=02:00:00
+
+set -e
+
+source .venv/bin/activate
+
+python scripts/artificial_humans/contribution_copula_rho.py \
+    --model "$1" --out "$2" --preflight --roundtrip

--- a/scripts/artificial_humans/contribution_copula_rho.py
+++ b/scripts/artificial_humans/contribution_copula_rho.py
@@ -170,9 +170,17 @@ def describe(tr, label):
 # --------------------------------------------------------------------------- #
 def compare_saved(before, after):
     """Every saved key except `copula_rho` must survive the round trip
-    unchanged -- module weights compared parameter by parameter."""
+    unchanged -- module weights compared parameter by parameter. Legacy
+    artifacts predate `edge_encoding` in GraphNetwork.save's key list; the
+    re-save may add it only as the reconstructed default (empty)."""
     assert set(before) - set(after) == set(), "a saved key disappeared"
-    assert set(after) - set(before) <= {"copula_rho"}, "an unexpected key appeared"
+    extra = set(after) - set(before)
+    assert extra <= {"copula_rho", "edge_encoding"}, "an unexpected key appeared"
+    if "edge_encoding" in extra:
+        assert after["edge_encoding"] in ([], None), (
+            "edge_encoding appeared with a non-default value: "
+            f"{after['edge_encoding']!r}"
+        )
     for k, va in before.items():
         if k == "copula_rho":
             continue

--- a/scripts/artificial_humans/contribution_copula_rho.py
+++ b/scripts/artificial_humans/contribution_copula_rho.py
@@ -1,0 +1,438 @@
+"""Calibrate `copula_rho` for the GNN contributor's within-round copula.
+
+Estimates the within-(episode, round, agent_group) latent correlation of human
+contributions by pairwise-likelihood MLE of an exchangeable Gaussian copula
+(each observation keeps the model's own predicted discrete marginal), on the
+40 single-copy baseline train episodes only, and writes a copy of the input
+artifact with `copula_rho` stamped in plus a JSON provenance sidecar. The
+randomized-PIT moment estimator is printed as an attenuated diagnostic only.
+
+The estimator, the bootstrap, the round-trip gate and the pre-flight are
+imported unmodified from the punisher calibration (PR #146,
+scripts/baselines/punishment_copula_rho.py); only the marginals differ -- they
+come from a teacher-forced GNN forward pass instead of a linear bundle. Method
+details: notes/autoresearch_log/punisher-severity-copula.md (appendix) and
+notes/autoresearch_log/contribution-cg-copula.md.
+
+Imports graph.py, so this runs on Raven only:
+    .venv/bin/python scripts/artificial_humans/contribution_copula_rho.py \
+        --model IN.pt --out OUT.pt [--preflight] [--roundtrip]
+"""
+
+import argparse
+import json
+import os
+import random
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+os.environ.setdefault("DISABLE_PANDERA_IMPORT_WARNING", "True")
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import torch as th  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(ROOT / "scripts" / "baselines"))
+
+# the #146 estimator machinery, imported unmodified: that module's top level is
+# imports, constants and defs only, so importing it runs no calibration
+import punishment_copula_rho as pc  # noqa: E402
+
+# pytorch geometric meta module has changed place since the artifacts were
+# saved; the alias lets the legacy pickles load (simulate.py does the same)
+import torch_geometric.nn.models.meta as meta_module  # noqa: E402
+
+sys.modules["torch_geometric.nn.meta"] = meta_module
+
+from aimanager.generic.data import create_torch_data  # noqa: E402
+from aimanager.generic.graph import GraphNetwork  # noqa: E402
+
+f = pc.f  # unrounded float for the log
+FULL = ROOT / "experiments/2group_8agent_50ep.csv"
+TRAIN = ROOT / "experiments/baseline/2group_8agent_50ep_bline_train.csv"
+TEST = ROOT / "experiments/baseline/2group_8agent_50ep_bline_test.csv"
+EXPERIMENTS = ["ah_group_switching"]
+MASK = "contribution_valid"
+SWITCH_EVERY = None  # the contribution configs carry no switch_every
+SEED = pc.SEED  # 38381, also the AH training seed
+N_GROUPS = 2
+N_TRAIN_EP = 40
+N_TEST_EP = 10
+
+
+# --------------------------------------------------------------------------- #
+# data: the training loader on the FULL file, then the split's own episodes
+# --------------------------------------------------------------------------- #
+def rel(path):
+    """Repo-relative path when possible, absolute otherwise (logging only)."""
+    try:
+        return str(Path(path).resolve().relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def episode_key(df):
+    """The (global_group_id, episode_id) key parse_agent_rounds dense-ranks
+    into `group_idx` -- recomputed here because the column is dropped before
+    the tensors are built."""
+    return df["global_group_id"] + "__" + df["episode_id"].astype(str)
+
+
+def load_full():
+    """create_torch_data on the FULL human file, so every default and median
+    (contribution default, common-good rescaling) is exactly the one the model
+    trained with. Returns the tensors, the per-episode pair_id, and the
+    key -> episode-row map."""
+    th.random.manual_seed(SEED)
+    np.random.seed(SEED)
+    random.seed(SEED)
+    df = pd.read_csv(FULL)
+    df = df[df["experiment_name"].isin(EXPERIMENTS)]
+    data, default_values, pair_id = create_torch_data(
+        df, switch_every=SWITCH_EVERY
+    )
+    key = episode_key(df)
+    idx = key.rank(method="dense").astype(int) - 1
+    key_to_idx = dict(zip(key, idx))
+    assert len(key_to_idx) == data["contribution"].shape[0], "key/tensor mismatch"
+    return data, np.asarray(pair_id), key_to_idx, default_values
+
+
+def select_split(key_to_idx, path, n_expect):
+    """Episode rows of the split file. The flip-doubling lives in the CSV and
+    the model conditions on agent_group, so the two copies of a game carry
+    different marginals -- matching on the key takes exactly the copy the
+    split file holds (D5)."""
+    df = pd.read_csv(path)
+    keys = sorted(set(episode_key(df)))
+    missing = [k for k in keys if k not in key_to_idx]
+    assert not missing, f"{path.name}: {len(missing)} keys absent from {FULL.name}"
+    idx = np.array(sorted(key_to_idx[k] for k in keys), dtype=np.int64)
+    assert len(idx) == len(set(idx.tolist())) == n_expect, (
+        f"{path.name}: matched {len(set(idx.tolist()))} episodes, "
+        f"expected {n_expect}"
+    )
+    return idx
+
+
+def teacher_forced_rows(model, data, idx):
+    """Predicted marginals + observed levels + cell ids for every valid
+    contribution of the selected episodes. Teacher-forced: the model sees the
+    human history, never its own draws."""
+    sel = th.as_tensor(idx)
+    sub = {k: v[sel] for k, v in data.items()}
+    n_ep, n_agents, n_rounds = sub["contribution"].shape
+    with th.no_grad():  # predict_* leaves the graph attached otherwise
+        edge_index = model.create_fully_connected(n_agents, n_batch=n_ep)
+        _, proba = model.predict_independent(
+            sub, sample=False, reset_rnn=True, edge_index=edge_index
+        )
+    mask = sub[MASK].numpy().astype(bool)  # [G, A, T]
+    g, a, t = np.nonzero(mask)
+    # float64 of the float32 softmax, unfloored and unrenormalised: exactly
+    # the array the sampler in generic/copula.py inverts
+    P = proba.double().numpy()[mask]
+    assert np.abs(P.sum(1) - 1.0).max() < 1e-6, "predicted rows do not sum to 1"
+    y = sub["contribution"].numpy()[mask].astype(np.int64)
+    assert y.max() < P.shape[1], "observed level outside the model's support"
+    grp = sub["agent_group"].numpy()[mask].astype(np.int64)
+    return dict(
+        P=P,
+        y=y,
+        episode=g.astype(np.int64),
+        agent=a.astype(np.int64),
+        round=t.astype(np.int64),
+        group=grp,
+        cell=(g.astype(np.int64) * n_rounds + t) * N_GROUPS + grp,
+        shape=(n_ep, n_agents, n_rounds),
+    )
+
+
+def describe(tr, label):
+    _, _, sizes = pc.blocks(tr["cell"])
+    ii, jj = pc.pair_index(tr["cell"])
+    n_ep, n_agents, n_rounds = tr["shape"]
+    print(f"{label}: episodes={n_ep} agents={n_agents} rounds={n_rounds}")
+    print(
+        f"  rows={len(tr['y'])} cells={len(sizes)} "
+        f"cells>=2={(sizes >= 2).sum()} pairs={len(ii)}"
+    )
+    print(f"  cell size histogram={np.bincount(sizes).tolist()}")
+    return ii, jj, sizes
+
+
+# --------------------------------------------------------------------------- #
+# artifact write: the .pt carries rho, a JSON sidecar carries the provenance
+# (GraphNetwork.save writes a fixed key list, so nothing else may ride along)
+# --------------------------------------------------------------------------- #
+def compare_saved(before, after):
+    """Every saved key except `copula_rho` must survive the round trip
+    unchanged -- module weights compared parameter by parameter."""
+    assert set(before) - set(after) == set(), "a saved key disappeared"
+    assert set(after) - set(before) <= {"copula_rho"}, "an unexpected key appeared"
+    for k, va in before.items():
+        if k == "copula_rho":
+            continue
+        vb = after[k]
+        if isinstance(va, th.nn.Module):
+            sa, sb = va.state_dict(), vb.state_dict()
+            assert set(sa) == set(sb), f"{k}: parameter set changed"
+            for p in sa:
+                assert th.equal(sa[p], sb[p]), f"{k}.{p} changed"
+        elif isinstance(va, th.Tensor):
+            assert th.equal(va, vb), f"{k} changed"
+        else:
+            assert va == vb, f"{k} changed: {va!r} -> {vb!r}"
+
+
+def save_model(model, in_path, out_path, proba_ref, data, idx, meta):
+    """Stamp rho into a COPY of the artifact, then reload and prove that only
+    rho moved: the teacher-forced probabilities of the calibration rows must
+    come back bit-identical."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    model.copula_rho = float(meta["copula_rho"])
+    model.save(out_path)
+
+    loaded = GraphNetwork.load(str(out_path), device="cpu")
+    assert loaded.copula_rho == float(meta["copula_rho"]), "rho did not round-trip"
+    back = teacher_forced_rows(loaded, data, idx)
+    assert np.array_equal(back["P"], proba_ref), "reloaded logits are not identical"
+    compare_saved(
+        th.load(in_path, map_location="cpu"),
+        th.load(out_path, map_location="cpu"),
+    )
+
+    side = out_path.with_suffix(".copula.json")
+    side.write_text(json.dumps(meta, indent=2) + "\n")
+    print(f"\nsaved {rel(out_path)}")
+    print(f"  copula_rho={f(model.copula_rho)} estimator=pairwise_mle")
+    print("  teacher-forced probabilities: bit-identical after reload")
+    print("  every other saved key: unchanged vs the input artifact")
+    print(f"  provenance {rel(side)}")
+
+
+# --------------------------------------------------------------------------- #
+def main():
+    t0 = time.time()
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", required=True, help="input .pt (rho must be 0)")
+    ap.add_argument("--out", required=True, help="output .pt with rho stamped in")
+    ap.add_argument(
+        "--preflight",
+        action="store_true",
+        help="replay the human P matrices through the independent and the "
+        "copula sampler and print the group-spread ratios (go/no-go only)",
+    )
+    ap.add_argument(
+        "--roundtrip",
+        action="store_true",
+        help="acceptance gate: recover a known rho from synthetic copula data",
+    )
+    args = ap.parse_args()
+    in_path = Path(args.model).resolve()
+    out_path = Path(args.out).resolve()
+    assert in_path != out_path, "refusing to overwrite the input artifact"
+
+    model = GraphNetwork.load(str(in_path), device="cpu")
+    model.eval()
+    assert model.y_name == "contribution", f"not a contributor: {model.y_name}"
+    assert model.copula_rho == 0.0, f"input already carries {model.copula_rho}"
+    print(f"model     {rel(in_path)}")
+    print(
+        f"  y_name={model.y_name} y_levels={model.y_levels} "
+        f"autoregressive={model.autoregressive}"
+    )
+    print(f"  x_encoding={[e['name'] for e in model.x_encoding]}")
+    print(f"  edge_encoding={[e['name'] for e in model.edge_encoding]}")
+
+    data, pair_id, key_to_idx, defaults = load_full()
+    tr_idx = select_split(key_to_idx, TRAIN, N_TRAIN_EP)
+    te_idx = select_split(key_to_idx, TEST, N_TEST_EP)
+    assert not set(tr_idx.tolist()) & set(te_idx.tolist()), "train/test overlap"
+    assert not set(pair_id[tr_idx].tolist()) & set(
+        pair_id[te_idx].tolist()
+    ), "a flip copy of a train game sits in the holdout"
+    print(f"data      {rel(FULL)} (episodes={len(key_to_idx)})")
+    print(
+        f"  train split {rel(TRAIN)}: {len(tr_idx)} episodes, "
+        f"{len(set(pair_id[tr_idx].tolist()))} distinct games"
+    )
+    print(f"  contribution default={f(defaults['contribution'])}")
+
+    tr = teacher_forced_rows(model, data, tr_idx)
+    P, y, cell = tr["P"], tr["y"], tr["cell"]
+    ii, jj, sizes = describe(tr, "  teacher-forced rows")
+    order, starts, _ = pc.blocks(cell)
+    err = pc.check_bvn()
+    print(
+        f"  Phi_2 quadrature nodes={pc.N_QUAD}, max abs err vs scipy mvn="
+        f"{'unchecked' if err is None else f(err)}"
+    )
+
+    # ---------------- the estimator: pairwise-likelihood MLE ---------------- #
+    z_lo, z_hi = pc.cdf_bounds(P, y)
+    H, K, sgn = pc.rect_points(z_lo, z_hi, ii, jj)
+    t_mle = time.time()
+    rho_hat, nll_hat, nll0, n_ev = pc.rho_mle(H, K, sgn)
+    t_mle = time.time() - t_mle
+    print("\n=== rho: pairwise-likelihood MLE (train split) ===")
+    print(f"rho_hat                      {f(rho_hat)}")
+    print(f"  pairwise nll(rho_hat)      {f(nll_hat)}")
+    print(f"  pairwise nll(0)            {f(nll0)}")
+    print(
+        f"  2*(nll(0) - nll(rho_hat))  {f(2.0 * (nll0 - nll_hat))}  "
+        f"(pairwise LR, not chi2-calibrated)"
+    )
+    print(f"  n_pairs={len(ii)}  nll evals={n_ev}  fit {t_mle:.2f}s")
+
+    t_bs = time.time()
+    boot = pc.bootstrap_mle(P, y, cell, tr["episode"], pc.N_BOOT, SEED, rho_hat)
+    se = float(boot.std(ddof=1))
+    ci = (float(np.percentile(boot, 2.5)), float(np.percentile(boot, 97.5)))
+    print(f"cluster bootstrap ({pc.N_BOOT} resamples over {len(tr_idx)} episodes)")
+    print(f"  SE                         {f(se)}")
+    print(f"  95% percentile CI          [{f(ci[0])}, {f(ci[1])}]")
+    print(
+        f"  bootstrap min/max          {f(boot.min())} / {f(boot.max())}"
+        f"   [{time.time() - t_bs:.1f}s]"
+    )
+
+    # ---------------- acceptance gate ---------------- #
+    rt_bias = None
+    if args.roundtrip:
+        t_rt = time.time()
+        rows = pc.roundtrip(P, cell, (0.1, 0.2, 0.3, 0.4, 0.5), pc.N_ROUNDTRIP, SEED)
+        print(
+            f"\n=== ACCEPTANCE GATE: round-trip recovery "
+            f"({pc.N_ROUNDTRIP} synthetic datasets per rho) ==="
+        )
+        print(
+            "rho_true   rho_hat MLE            bias                   "
+            "rho_hat PIT (attenuated)"
+        )
+        for rho_true, mle, pit in rows:
+            print(f"{rho_true:<10.2f} {f(mle):<22} {f(mle - rho_true):<22} {f(pit)}")
+        rt_bias = max(abs(m - r) for r, m, _ in rows)
+        print(
+            f"max |bias| = {f(rt_bias)}  -> "
+            f"{'PASS' if rt_bias <= 0.03 else 'FAIL'} (tolerance 0.03)"
+            f"   [{time.time() - t_rt:.1f}s]"
+        )
+
+    # ---------------- attenuated diagnostic: randomized PIT ---------------- #
+    Z, z_mid = pc.latents(P, y, pc.N_PIT, SEED)
+    Zo = Z[order]
+    rho_reps, _ = pc.rho_pairs(Zo, starts, sizes)
+    mid_rho, _ = pc.rho_pairs(z_mid[order][:, None], starts, sizes)
+    print(
+        f"\n=== ATTENUATED DIAGNOSTIC: randomized-PIT moment estimator "
+        f"(R={pc.N_PIT}) ==="
+    )
+    print(f"rho_pit (pair-weighted)      {f(rho_reps.mean())}")
+    print(f"  per-replicate min/max      {f(rho_reps.min())} / {f(rho_reps.max())}")
+    print(f"  replicate sd               {f(rho_reps.std(ddof=1))}")
+    print(f"cross-check per-cell weight  {f(pc.rho_cells(Zo, starts, sizes).mean())}")
+    print(f"cross-check ICC(1) one-way   {f(pc.icc_oneway(Zo, starts, sizes).mean())}")
+    print(f"sensitivity mid-point PIT    {f(mid_rho[0])}")
+    boot_pit = pc.bootstrap_pit(
+        Zo, cell[order], tr["episode"][order], pc.N_BOOT_PIT, SEED
+    )
+    print(
+        f"cluster bootstrap ({pc.N_BOOT_PIT} resamples, crossed with the "
+        f"{pc.N_PIT} PIT replicates)"
+    )
+    print(f"  SE                         {f(boot_pit.std(ddof=1))}")
+    print(
+        f"  95% percentile CI          [{f(np.percentile(boot_pit, 2.5))}, "
+        f"{f(np.percentile(boot_pit, 97.5))}]"
+    )
+
+    # ---------------- diagnostic splits ---------------- #
+    print("\n=== diagnostic splits only (never a selection criterion) ===")
+    print("split                        rho MLE                 rho PIT (att.)")
+    rounds = tr["round"]
+
+    def split(label, sel):
+        mle, n_pr, n_rows, n_cells = pc.mle_on_rows(P, y, cell, sel)
+        pit = pc.pit_on_subset(Z, cell, sel)[0]
+        print(
+            f"{label:<28} {f(mle):<23} {f(pit):<23} "
+            f"rows={n_rows} cells>=2={n_cells} pairs={n_pr}"
+        )
+
+    n_rounds = tr["shape"][2]
+    split("excluding round 0", rounds > 0)
+    for third in np.array_split(np.arange(n_rounds), 3):
+        split(f"rounds {third[0]}-{third[-1]}", np.isin(rounds, third))
+    size_of_cell = dict(zip(cell[order][starts], sizes))
+    row_size = np.array([size_of_cell[c] for c in cell])
+    for s in sorted(set(sizes.tolist())):
+        if s >= 2:
+            split(f"cell size {s}", row_size == s)
+
+    # ---------------- out-of-sample check ---------------- #
+    te = teacher_forced_rows(model, data, te_idx)
+    mle_te, pr_te, rows_te, cells_te = pc.mle_on_rows(te["P"], te["y"], te["cell"])
+    Z_te, _ = pc.latents(te["P"], te["y"], pc.N_PIT, SEED)
+    o_te, s_te, sz_te = pc.blocks(te["cell"])
+    pit_te, _ = pc.rho_pairs(Z_te[o_te], s_te, sz_te)
+    print(
+        f"\nOUT-OF-SAMPLE CHECK ONLY ({rel(TEST)}, "
+        f"episodes={len(te_idx)})"
+    )
+    print(
+        f"  rho MLE={f(mle_te)}  rho PIT={f(pit_te.mean())}  "
+        f"rows={rows_te} cells>=2={cells_te} pairs={pr_te}"
+    )
+
+    # ---------------- pre-flight ---------------- #
+    pf = None
+    if args.preflight:
+        ind, cop, human = pc.preflight(
+            P, y, cell, rho_hat, pc.N_PREFLIGHT, SEED
+        )
+        pf = dict(independent=ind, copula=cop, human=human)
+        print(
+            f"\n=== pre-flight (go/no-go; rho is NEVER tuned to it), "
+            f"{pc.N_PREFLIGHT} repeats ==="
+        )
+        print(f"group-spread ratio independent  {f(ind)}")
+        print(f"group-spread ratio copula       {f(cop)}  (rho={f(rho_hat)})")
+        print(f"group-spread ratio human        {f(human)}")
+
+    meta = dict(
+        copula_rho=float(rho_hat),
+        copula_rho_se=se,
+        copula_rho_ci=[ci[0], ci[1]],
+        copula_estimator="pairwise_mle",
+        copula_diag_pit="randomized",  # provenance of the diagnostic only
+        copula_diag_pit_rho=float(rho_reps.mean()),
+        copula_cell_key="episode_round_agent_group",
+        copula_data_file=rel(TRAIN),
+        copula_data_note=(
+            "create_torch_data on the full human file (training defaults), "
+            "restricted to the 40 single-copy train episodes; teacher-forced "
+            "marginals from the source model; rows where contribution_valid"
+        ),
+        copula_n_rows=int(len(y)),
+        copula_n_cells=int((sizes >= 2).sum()),
+        copula_n_pairs=int(len(ii)),
+        copula_n_episodes=int(len(tr_idx)),
+        copula_roundtrip_max_bias=rt_bias,
+        copula_preflight=pf,
+        copula_holdout_rho=float(mle_te),
+        source_model=rel(in_path),
+        model=rel(out_path),
+        script=rel(__file__),
+        seed=SEED,
+        date=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    )
+    save_model(model, in_path, out_path, tr["P"], data, tr_idx, meta)
+    print(f"total runtime {time.time() - t0:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aimanager/generic/copula.py
+++ b/src/aimanager/generic/copula.py
@@ -1,0 +1,70 @@
+"""Exchangeable Gaussian copula over categorical rows (pure torch, no PyG).
+
+Mirrors ``LinearAHAdapter._sample_levels_copula`` so the GNN and the linear
+baselines sample the same way; conventions and rationale:
+notes/autoresearch_log/punisher-severity-copula.md (appendix).
+"""
+
+import math
+
+import torch as th
+
+
+def _first_member(cells_flat, n_rows, device):
+    """Row index of the first occurrence of each cell id, indexed by the cell's
+    position in ``th.unique``. Sort-based because ``scatter_reduce`` with amin
+    is unavailable on the pinned torch 1.11 and duplicate-index ``index_copy_``
+    is nondeterministic on CUDA."""
+    _, inverse = th.unique(cells_flat, return_inverse=True)
+    idx = th.arange(n_rows, device=device)
+    # unique key sorting lexicographically by (cell, row): no tie to break
+    order = th.argsort(inverse * n_rows + idx)
+    inv_sorted = inverse[order]
+    is_first = th.ones_like(inv_sorted, dtype=th.bool)
+    is_first[1:] = inv_sorted[1:] != inv_sorted[:-1]
+    first = th.zeros(int(is_first.sum()), dtype=th.int64, device=device)
+    first[inv_sorted[is_first]] = order[is_first]
+    return first[inverse]
+
+
+def sample_levels_copula(proba, cells, rho):
+    """Sample one level per row, rows of a cell sharing a Gaussian latent:
+    ``u_i = Phi(sqrt(rho) z_c(i) + sqrt(1-rho) eps_i)``, inverted through the
+    row's own CDF as ``min{a : F_i(a) >= u_i}``. Marginals are therefore the
+    caller's ``proba`` exactly, whatever rho -- only the dependence changes.
+
+    ``proba`` is (..., K) with rows summing to 1 (caller-guaranteed), ``cells``
+    is int64 of shape ``proba.shape[:-1]``, ``rho`` lies in [0, 1). Returns
+    int64 levels in [0, K-1] of shape ``cells.shape``.
+
+    Conventions that the code alone cannot show:
+    - exactly 2N draws per call (``zs`` then ``eps``, float64, global torch
+      RNG), whatever the cell composition, so the RNG stream is
+      composition-stable and rho == 0.0 reduces to independent sampling
+      through this same path rather than a shorter one;
+    - a cell's latent is the ``zs`` slot of its first member in flattened row
+      order, matching the adapter's first-member rule;
+    - Phi is ``0.5 (1 + erf(x / sqrt 2))``, bitwise equal to the adapter's
+      ``th.special.ndtr`` in float64 on the tested platforms;
+    - the final clamp guards u == 1.0 and cumsum overshoot, not a modelling
+      choice.
+    """
+    assert 0.0 <= rho < 1.0, f"rho must lie in [0, 1), got {rho}"
+    assert (
+        cells.shape == proba.shape[:-1]
+    ), f"cells {tuple(cells.shape)} does not match proba {tuple(proba.shape)}"
+
+    device = proba.device
+    n_levels = proba.shape[-1]
+    flat = proba.reshape(-1, n_levels).double()
+    n_rows = flat.shape[0]
+
+    zs = th.randn(n_rows, dtype=th.float64, device=device)
+    eps = th.randn(n_rows, dtype=th.float64, device=device)
+    pick = _first_member(cells.reshape(-1), n_rows, device)
+
+    x = math.sqrt(rho) * zs[pick] + math.sqrt(1.0 - rho) * eps
+    u = 0.5 * (1.0 + th.erf(x / math.sqrt(2.0)))
+    cum = flat.cumsum(-1).contiguous()
+    lvl = th.searchsorted(cum, u.reshape(-1, 1).contiguous()).reshape(-1)
+    return lvl.clamp(0, n_levels - 1).reshape(cells.shape)

--- a/src/aimanager/generic/graph.py
+++ b/src/aimanager/generic/graph.py
@@ -3,6 +3,7 @@ import numpy as np
 import torch as th
 from torch_scatter import scatter_mean
 from torch_geometric.nn import MetaLayer
+from aimanager.generic.copula import sample_levels_copula
 from aimanager.generic.encoder import Encoder, IntEncoder
 
 
@@ -144,6 +145,7 @@ class GraphNetwork(th.nn.Module):
         add_global_model=True,
         hidden_size=None,
         default_values={},
+        copula_rho=0.0,
         **_,
     ):
         super().__init__()
@@ -167,6 +169,19 @@ class GraphNetwork(th.nn.Module):
         self.y_levels = y_levels
         self.y_name = y_name
         self.autoregressive = autoregressive
+        # Contribution copula: `copula_rho` > 0 correlates the free-running
+        # draws of agents sharing a (episode, round, agent_group) cell, keeping
+        # each agent's marginal (calibrated by
+        # scripts/artificial_humans/contribution_copula_rho.py). Absent or 0.0
+        # keeps the pre-change independent draw, RNG consumption included.
+        self.copula_rho = float(copula_rho or 0.0)
+        assert (
+            0.0 <= self.copula_rho < 1.0
+        ), f"copula_rho must lie in [0, 1), got {self.copula_rho}"
+        assert self.copula_rho == 0.0 or y_name == "contribution", (
+            "copula_rho is implemented for the contribution sampler only, "
+            f"got y_name={y_name!r}"
+        )
 
         if op1 is None:
             if add_edge_model:
@@ -334,11 +349,27 @@ class GraphNetwork(th.nn.Module):
         )
         return encoded
 
-    def predict_encoded(self, data, sample=True, reset_rnn=True):
+    def copula_cells(self, agent_group, n_batch, n_nodes, n_rounds, device=None):
+        """Cell ids for the copula sampler, one cell per (episode, round,
+        agent_group), shaped like the decode input: rows are (batch, agent)
+        flattened as in `encode`, rounds on dim 1. agent_group is time-varying,
+        so the cell of an agent follows it when it switches."""
+        device = self.device if device is None else device
+        ag = agent_group.flatten(0, 1).to(device)
+        n_groups = int(ag.max().item()) + 1
+        episode = th.arange(n_batch, device=device).repeat_interleave(n_nodes)
+        rounds = th.arange(n_rounds, device=device)
+        base = (episode.unsqueeze(-1) * n_rounds + rounds.unsqueeze(0)) * n_groups
+        return base + ag
+
+    def predict_encoded(self, data, sample=True, reset_rnn=True, cells=None):
         self.eval()
         y_logit = self(data, reset_rnn)
         y_pred_proba = th.nn.functional.softmax(y_logit, dim=-1)
-        y_pred = self.y_encoder.decode(y_pred_proba, sample)
+        if sample and self.copula_rho > 0.0 and cells is not None:
+            y_pred = sample_levels_copula(y_pred_proba, cells, self.copula_rho)
+        else:
+            y_pred = self.y_encoder.decode(y_pred_proba, sample)
         return y_pred, y_pred_proba
 
     def predict_independent(self, data, sample=True, reset_rnn=True, edge_index=None):
@@ -348,7 +379,18 @@ class GraphNetwork(th.nn.Module):
         encoded = self.encode(
             data, y_encode=False, edge_index=edge_index, device=self.device
         )
-        predict = self.predict_encoded(encoded, sample=sample, reset_rnn=reset_rnn)
+        # A calibrated model must never silently lose its correlation on the
+        # sampling path; teacher-forced callers of predict_encoded keep the
+        # quiet cells=None fallback instead.
+        cells = None
+        if self.copula_rho > 0.0 and sample:
+            assert "agent_group" in data, "copula_rho > 0 needs agent_group"
+            cells = self.copula_cells(
+                data["agent_group"], n_batch, n_nodes, n_rounds, device=self.device
+            )
+        predict = self.predict_encoded(
+            encoded, sample=sample, reset_rnn=reset_rnn, cells=cells
+        )
         predict = tuple(t.reshape((n_batch, n_nodes, *t.shape[1:])) for t in predict)
         return predict
 
@@ -436,6 +478,7 @@ class GraphNetwork(th.nn.Module):
             "edge_encoding",
             "b_encoding",
             "default_values",
+            "copula_rho",
         ]
         th.save({k: getattr(self, k) for k in to_save}, filename)
 

--- a/src/aimanager/tests/test_contribution_copula_gnn.py
+++ b/src/aimanager/tests/test_contribution_copula_gnn.py
@@ -1,0 +1,369 @@
+"""Wiring tests for the contribution copula inside GraphNetwork: induced
+within-group correlation at rho > 0 with marginals intact, a bit-identical
+legacy path (RNG consumption included) at rho == 0, save/load round-trip of
+`copula_rho`, the __init__ gate, the cell construction, and the sim-path
+assert. Sampler-level invariants live in tests/copula (pure torch, local);
+this file imports graph.py and therefore PyG, so it runs on Raven:
+
+    scripts/remote_test.sh -- src/aimanager/tests/test_contribution_copula_gnn.py -v
+"""
+
+import math
+import os
+import sys
+import tempfile
+
+import numpy as np
+import pytest
+import torch as th
+
+# pytorch geometric meta module has changed place since the committed
+# artifacts were saved; the alias lets legacy pickles unpickle (simulate.py
+# installs the same one before loading a model)
+import torch_geometric.nn.models.meta as meta_module
+
+sys.modules["torch_geometric.nn.meta"] = meta_module
+
+from aimanager.generic.graph import GraphNetwork  # noqa: E402
+
+N_LEVELS = 21
+N_AGENTS = 8
+GROUPS = [0, 0, 0, 0, 1, 1, 1, 1]
+RHO = 0.4
+N_DRAW = 400  # predict repeats for the marginal / correlation tests
+M0 = (
+    "artifacts/artificial_humans/group_switching_contribution_50ep/model/"
+    "architecture_node+edge+rnn__dataset_50ep__epochs_575.pt"
+)
+WITHIN = [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3), (4, 5), (4, 6), (5, 7)]
+CROSS = [(0, 4), (0, 5), (1, 6), (2, 7), (3, 4), (3, 7)]
+
+
+# --------------------------------------------------------------------------- #
+# toy model and data
+# --------------------------------------------------------------------------- #
+def make_model(y_name="contribution", **over):
+    """Smallest workable contribution GNN (same shape as the edge-encoder
+    tests'), seeded so the readout is fixed across constructions."""
+    th.manual_seed(0)
+    kwargs = dict(
+        y_levels=N_LEVELS,
+        y_name=y_name,
+        hidden_size=4,
+        add_rnn=True,
+        add_edge_model=True,
+        add_global_model=False,
+        x_encoding=[
+            {"name": "prev_contribution", "n_levels": 21, "encoding": "numeric"}
+        ],
+        edge_encoding=[],
+        default_values={},
+    )
+    kwargs.update(over)
+    return GraphNetwork(**kwargs).to("cpu")
+
+
+def make_data(n_batch=4, n_player=N_AGENTS, n_rounds=2, uniform=True, groups=GROUPS):
+    """Toy batch. `uniform` gives every agent the same features, so all rows
+    share one marginal and a level correlation can only come from the shared
+    latent -- never from shared inputs."""
+    shape = (n_batch, n_player, n_rounds)
+    if uniform:
+        prev = th.full(shape, 9, dtype=th.int64)
+    else:
+        th.manual_seed(1)
+        prev = th.randint(0, 21, shape)
+    ag = th.tensor(groups, dtype=th.int64).reshape(1, -1, 1).expand(shape)
+    return {
+        "contribution": th.zeros(shape, dtype=th.int64),
+        "prev_contribution": prev,
+        "agent_group": ag.contiguous(),
+    }
+
+
+def legacy_predict(model, data):
+    """The contribution draw as committed BEFORE this change, reimplemented
+    verbatim from graph.py (encode -> forward -> softmax -> the one-line
+    multinomial decode), so the comparison does not depend on the code under
+    test."""
+    n_batch, n_nodes, n_rounds = data[model.y_name].shape
+    edge_index = model.create_fully_connected(n_nodes, n_batch=n_batch)
+    encoded = model.encode(
+        data, y_encode=False, edge_index=edge_index, device=model.device
+    )
+    model.eval()
+    proba = th.nn.functional.softmax(model(encoded, True), dim=-1)
+    dec = th.multinomial(proba.reshape(-1, proba.shape[-1]), 1)
+    lvl = dec.reshape(proba.shape[:-1])
+    return lvl.reshape((n_batch, n_nodes, *lvl.shape[1:]))
+
+
+def pair_corr(draws, pairs):
+    return float(
+        np.mean([np.corrcoef(draws[:, i], draws[:, j])[0, 1] for i, j in pairs])
+    )
+
+
+@pytest.fixture(scope="module")
+def sampled():
+    """N_DRAW free-running predictions of one fixed batch, at rho=RHO and at
+    rho=0, plus the (identical, teacher-forced) probabilities they must
+    reproduce. Round 0 only; episodes are independent cells, so they stack."""
+    data = make_data()
+    out = {}
+    for name, rho in (("copula", RHO), ("rho0", 0.0)):
+        model = make_model(copula_rho=rho)
+        th.manual_seed(11)
+        draws = [
+            model.predict_independent(data, sample=True)[0][:, :, 0]
+            for _ in range(N_DRAW)
+        ]
+        out[name] = th.stack(draws).reshape(-1, N_AGENTS).numpy()
+    model = make_model(copula_rho=RHO)
+    # predict_* leaves the graph attached (eval, no no_grad) -> detach to read
+    proba = model.predict_independent(data, sample=False)[1].detach()
+    out["proba"] = proba[0, :, 0].double()
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# (a) the mechanism through predict_independent
+# --------------------------------------------------------------------------- #
+def test_marginals_match_predicted_proba(sampled):
+    """Free-running levels must reproduce the model's own probabilities within
+    4 binomial SEs, rho or no rho -- the copula moves dependence only. Levels
+    with fewer than 20 expected counts are skipped (normal approximation)."""
+    P = sampled["proba"].numpy()
+    n = len(sampled["copula"])
+    for source in ("copula", "rho0"):
+        worst = 0.0
+        for agent in range(N_AGENTS):
+            freq = np.bincount(sampled[source][:, agent], minlength=N_LEVELS) / n
+            for lvl in range(N_LEVELS):
+                p = P[agent, lvl]
+                if p * n < 20:
+                    continue
+                se = math.sqrt(p * (1.0 - p) / n)
+                worst = max(worst, abs(freq[lvl] - p) / se)
+        assert worst < 4.0, f"{source}: worst deviation {worst:.2f} binomial SEs"
+
+
+def test_within_group_correlation_induced(sampled):
+    n = len(sampled["copula"])
+    within = pair_corr(sampled["copula"], WITHIN)
+    assert within > 6.0 / math.sqrt(n), f"within-group corr {within:.4f}"
+
+
+def test_cross_group_correlation_absent(sampled):
+    n = len(sampled["copula"])
+    cross = pair_corr(sampled["copula"], CROSS)
+    assert abs(cross) < 4.0 / math.sqrt(n), f"cross-group corr {cross:.4f}"
+
+
+def test_rho_zero_leaves_agents_independent(sampled):
+    n = len(sampled["rho0"])
+    for pairs, label in ((WITHIN, "within"), (CROSS, "cross")):
+        corr = pair_corr(sampled["rho0"], pairs)
+        assert abs(corr) < 4.0 / math.sqrt(n), f"{label} corr {corr:.4f} at rho=0"
+
+
+def test_within_beats_cross(sampled):
+    n = len(sampled["copula"])
+    within = pair_corr(sampled["copula"], WITHIN)
+    cross = pair_corr(sampled["copula"], CROSS)
+    assert within > cross + 5.0 / math.sqrt(n)
+
+
+# --------------------------------------------------------------------------- #
+# (b) the legacy path is bit-identical at rho == 0
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("over", [{}, {"copula_rho": 0.0}])
+def test_rho_zero_bit_identical_to_legacy(over):
+    """Three consecutive calls under one seed: identical levels AND identical
+    RNG consumption (an extra draw would desynchronise call 2)."""
+    model = make_model(**over)
+    assert model.copula_rho == 0.0
+    data = make_data(uniform=False)
+
+    th.manual_seed(42)
+    want = [legacy_predict(model, data) for _ in range(3)]
+    want_next = th.randn(1).item()  # where the legacy path leaves the stream
+    th.manual_seed(42)
+    got = [model.predict_independent(data, sample=True)[0] for _ in range(3)]
+    got_next = th.randn(1).item()
+
+    for i, (w, g) in enumerate(zip(want, got)):
+        assert th.equal(w, g), f"call {i}: {w.tolist()} != {g.tolist()}"
+    assert got_next == want_next, "RNG consumption changed"
+
+
+def test_copula_path_is_reached_at_rho_above_zero():
+    """Guard against a vacuous (b): at rho > 0 the levels must NOT match the
+    legacy draw under the same seed, or the branch is never taken."""
+    model = make_model(copula_rho=RHO)
+    data = make_data(uniform=False)
+    th.manual_seed(42)
+    legacy = legacy_predict(model, data)
+    th.manual_seed(42)
+    got = model.predict_independent(data, sample=True)[0]
+    assert not th.equal(legacy, got)
+
+
+def test_teacher_forced_probabilities_untouched():
+    """sample=False is the training/evaluation path: argmax, no draw, and the
+    probabilities identical to a rho-free model's."""
+    data = make_data(uniform=False)
+    cop = make_model(copula_rho=RHO)
+    ind = make_model()
+    pred_c, proba_c = cop.predict_independent(data, sample=False)
+    pred_i, proba_i = ind.predict_independent(data, sample=False)
+    assert th.equal(proba_c, proba_i)
+    assert th.equal(pred_c, pred_i)
+    assert th.equal(pred_c, proba_c.argmax(-1))
+
+
+# --------------------------------------------------------------------------- #
+# (c) save / load
+# --------------------------------------------------------------------------- #
+def test_save_load_round_trips_copula_rho():
+    model = make_model(copula_rho=RHO)
+    data = make_data(uniform=False)
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "model.pt")
+        model.save(path)
+        assert "copula_rho" in th.load(path, map_location="cpu")
+        loaded = GraphNetwork.load(path, device="cpu")
+        assert loaded.copula_rho == RHO
+        assert th.equal(
+            loaded.predict_independent(data, sample=False)[1],
+            model.predict_independent(data, sample=False)[1],
+        )
+
+        # a checkpoint saved before this change has no key at all
+        saved = th.load(path, map_location="cpu")
+        del saved["copula_rho"]
+        legacy_path = os.path.join(d, "legacy.pt")
+        th.save(saved, legacy_path)
+        legacy = GraphNetwork.load(legacy_path, device="cpu")
+        assert legacy.copula_rho == 0.0
+
+
+def test_committed_m0_loads_at_rho_zero():
+    """The reference contribution artifact must load unchanged and stay on the
+    independent path until a calibrated copy is stamped."""
+    if not os.path.exists(M0):  # pragma: no cover
+        pytest.skip(f"{M0} missing")
+    model = GraphNetwork.load(M0, device="cpu")
+    assert model.copula_rho == 0.0
+    assert model.y_name == "contribution"
+
+
+# --------------------------------------------------------------------------- #
+# (d) the __init__ gate
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("rho", [1.0, 1.5, -0.1])
+def test_gate_rejects_rho_outside_unit_interval(rho):
+    with pytest.raises(AssertionError, match=r"\[0, 1\)"):
+        make_model(copula_rho=rho)
+
+
+@pytest.mark.parametrize("y_name", ["punishment", "does_switch", "contribution_valid"])
+def test_gate_rejects_rho_on_other_targets(y_name):
+    """The switch, valid and punishment GNNs share this class; a rho must be
+    impossible on them."""
+    with pytest.raises(AssertionError, match="contribution sampler only"):
+        make_model(y_name=y_name, y_levels=2, copula_rho=RHO)
+
+
+@pytest.mark.parametrize("y_name", ["punishment", "does_switch"])
+def test_gate_accepts_other_targets_without_rho(y_name):
+    assert make_model(y_name=y_name, y_levels=2).copula_rho == 0.0
+
+
+@pytest.mark.parametrize("rho", [None, 0.0])
+def test_gate_accepts_absent_rho(rho):
+    assert make_model(copula_rho=rho).copula_rho == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# (e) cell construction
+# --------------------------------------------------------------------------- #
+def test_copula_cells_layout_and_sharing():
+    """(B*A, T) ids, laid out like the decode input: equal within an
+    (episode, round, group), distinct across any two of them."""
+    n_batch, n_agents, n_rounds = 2, 4, 3
+    ag = th.tensor(
+        [
+            [[0, 0, 1], [0, 1, 1], [1, 1, 0], [1, 1, 1]],
+            [[0, 0, 0], [0, 0, 1], [1, 1, 1], [1, 0, 1]],
+        ]
+    )
+    model = make_model()
+    cells = model.copula_cells(ag, n_batch, n_agents, n_rounds, device="cpu")
+    assert cells.shape == (n_batch * n_agents, n_rounds)
+    seen = {}
+    for b in range(n_batch):
+        for t in range(n_rounds):
+            for p in range(n_agents):
+                key = (b, t, int(ag[b, p, t]))
+                cid = int(cells[b * n_agents + p, t])
+                assert seen.setdefault(cid, key) == key, "cell id collision"
+                for q in range(n_agents):
+                    same_cell = cells[b * n_agents + p, t] == cells[b * n_agents + q, t]
+                    assert bool(same_cell) == (ag[b, p, t] == ag[b, q, t])
+
+
+def test_copula_cells_follow_a_switching_agent():
+    """agent_group is time-varying: an agent that switches mid-episode joins
+    its new group's cell in the round it switches."""
+    ag = th.tensor([[[0, 1], [0, 0], [1, 1], [1, 1]]])  # agent 0 switches at t=1
+    model = make_model()
+    cells = model.copula_cells(ag, 1, 4, 2, device="cpu")
+    assert cells[0, 0] == cells[1, 0] and cells[0, 0] != cells[2, 0]
+    assert cells[0, 1] == cells[2, 1] and cells[0, 1] != cells[1, 1]
+
+
+def test_copula_cells_match_the_decode_layout():
+    """The ids predict_independent builds must line up with the rows the
+    decode call sees: encode flattens (batch, agent), rounds stay on dim 1."""
+    data = make_data(n_batch=3, n_rounds=2, uniform=False)
+    model = make_model(copula_rho=RHO)
+    proba = model.predict_independent(data, sample=False)[1]
+    assert proba.shape == (3, N_AGENTS, 2, N_LEVELS)
+    # predict_encoded sees proba before predict_independent's reshape
+    decode_shape = proba.reshape(3 * N_AGENTS, 2, N_LEVELS).shape[:-1]
+    cells = model.copula_cells(data["agent_group"], 3, N_AGENTS, 2, device="cpu")
+    assert cells.shape == decode_shape
+
+
+# --------------------------------------------------------------------------- #
+# (f) the sim-path assert
+# --------------------------------------------------------------------------- #
+def test_missing_agent_group_raises_when_sampling():
+    """A calibrated model must never silently lose its correlation: no
+    agent_group on the free-running path is an error, not a fallback."""
+    model = make_model(copula_rho=RHO)
+    data = make_data(uniform=False)
+    del data["agent_group"]
+    with pytest.raises(AssertionError, match="agent_group"):
+        model.predict_independent(data, sample=True)
+
+
+def test_missing_agent_group_is_fine_when_teacher_forced():
+    """Teacher-forced evaluation draws nothing, so it needs no cells."""
+    model = make_model(copula_rho=RHO)
+    data = make_data(uniform=False)
+    del data["agent_group"]
+    pred, proba = model.predict_independent(data, sample=False)
+    assert th.equal(pred, proba.argmax(-1))
+    assert pred.shape == (4, N_AGENTS, 2)
+
+
+def test_rho_zero_without_agent_group_still_samples():
+    """The legacy models keep working on agent_group-free data."""
+    model = make_model()
+    data = make_data(uniform=False)
+    del data["agent_group"]
+    pred, _ = model.predict_independent(data, sample=True)
+    assert pred.shape == (4, N_AGENTS, 2)
+    assert int(pred.min()) >= 0 and int(pred.max()) <= N_LEVELS - 1

--- a/tests/copula/test_contribution_copula.py
+++ b/tests/copula/test_contribution_copula.py
@@ -1,0 +1,439 @@
+"""Unit tests for the contribution copula sampler
+(``aimanager.generic.copula.sample_levels_copula``): inverse-CDF convention,
+marginal preservation, within-cell (not cross-cell) correlation, determinism,
+composition-stable RNG consumption, the first-member latent rule, and parity
+with the punisher adapter's ``_sample_levels_copula`` (PR #146), which this
+module mirrors. Invariants and rationale:
+notes/autoresearch_log/contribution-cg-copula.md and
+notes/autoresearch_log/punisher-severity-copula.md (appendix).
+
+The module under test is PyG-free by construction, so this runs locally:
+    uv run python -m pytest tests/copula -v
+"""
+
+import math
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("DISABLE_PANDERA_IMPORT_WARNING", "True")
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+import torch as th  # noqa: E402
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[1]  # tests/copula -> repo root
+# this checkout's src must win over any installed/editable aimanager, so the
+# sampler under test is the one in THIS worktree
+sys.path.insert(0, str(ROOT / "src"))
+
+from aimanager.generic import copula  # noqa: E402
+from aimanager.generic.copula import sample_levels_copula  # noqa: E402
+from aimanager.simulation.linear_ah import LinearAHAdapter  # noqa: E402
+
+N_LEVELS = 21  # contribution levels 0..20
+N_AGENTS = 8
+GROUPS = [0, 0, 0, 0, 1, 1, 1, 1]
+N_DRAW = 20000  # sampling repeats for the marginal / correlation tests
+FEATS = ["prev_contribution", "prev_punishment", "round_number", "is_first"]
+DEFAULTS = {
+    "punishment": 0.0,
+    "contribution": 9.0,
+    "common_good": 12.333333333333334,
+    "agent_group": 0.0,
+    "contribution_valid": 0.0,
+    "punishment_valid": 0.0,
+    "recorded": 0.0,
+}
+# dyadic rows: exactly representable, so cumsum has no rounding slack and the
+# <= convention can be pinned AT the bin edge rather than merely near it
+DYADIC = [0.5, 0.25, 0.125, 0.0625, 0.0625]
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def contribution_proba(peak, n_levels=N_LEVELS, scale=2.5, seed=0):
+    """A contribution-like row: spike at the previous level with a smooth tail,
+    plus a little asymmetry so no test can pass on a symmetric accident."""
+    k = np.arange(n_levels, dtype=float)
+    w = np.exp(-np.abs(k - peak) / scale) + 0.02 * np.exp(-((k - 0.0) ** 2) / 8.0)
+    w = w * (1.0 + 0.15 * np.sin(k + seed))
+    return w / w.sum()
+
+
+def proba_block(peaks):
+    """(len(peaks), N_LEVELS) float32 proba, one contribution-like row each."""
+    rows = np.stack([contribution_proba(p, seed=i) for i, p in enumerate(peaks)])
+    return th.tensor(rows, dtype=th.float32)
+
+
+def repeat_rows(proba, n_draw):
+    """(n_draw, A, K) view of one A-row proba block, one repeat per row."""
+    return proba.unsqueeze(0).expand(n_draw, *proba.shape).contiguous()
+
+
+def repeat_cells(groups, n_draw):
+    """(n_draw, A) cells: the group pattern, made distinct per repeat so the
+    repeats are independent cells rather than one giant cell."""
+    g = th.tensor(groups, dtype=th.int64)
+    return g.unsqueeze(0) + th.arange(n_draw).unsqueeze(1) * (int(g.max()) + 1)
+
+
+def reference_levels(proba, cells, rho, member="first"):
+    """Hand-computed reference: 2N draws (zs then eps), latent from the FIRST
+    member of each cell in flattened row order (dict-based, as the punisher
+    adapter does it), inverted through each row's own CDF. Reimplemented here
+    so the comparison does not depend on the code under test. ``member="last"``
+    builds the rule the sampler must NOT be following."""
+    flat = proba.reshape(-1, proba.shape[-1]).double().numpy()
+    n = len(flat)
+    zs = th.randn(n, dtype=th.float64).numpy()
+    eps = th.randn(n, dtype=th.float64).numpy()
+    ids = [int(c) for c in cells.reshape(-1).tolist()]
+    slots = {}
+    for i, cid in enumerate(ids):
+        if member == "last" or cid not in slots:
+            slots[cid] = i
+    pick = np.array([slots[cid] for cid in ids], dtype=np.int64)
+    x = math.sqrt(rho) * zs[pick] + math.sqrt(1.0 - rho) * eps
+    u = 0.5 * (1.0 + np.vectorize(math.erf)(x / math.sqrt(2.0)))
+    cum = np.cumsum(flat, axis=1)
+    lvl = np.array([int(np.searchsorted(c, ui, "left")) for c, ui in zip(cum, u)])
+    return th.tensor(np.clip(lvl, 0, flat.shape[1] - 1)).reshape(cells.shape)
+
+
+def pair_corr(draws, pairs):
+    """Mean Pearson correlation of sampled levels over the given column pairs."""
+    return float(
+        np.mean([np.corrcoef(draws[:, i], draws[:, j])[0, 1] for i, j in pairs])
+    )
+
+
+WITHIN = [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3), (4, 5), (4, 6), (5, 7)]
+CROSS = [(0, 4), (0, 5), (1, 6), (2, 7), (3, 4), (3, 7)]
+
+
+# --------------------------------------------------------------------------- #
+# (a) inverse-CDF correctness on a hand-built proba
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "u, expected",
+    [
+        (1e-12, 0),  # far below F(0)
+        (0.25, 0),
+        (0.5, 0),  # exactly F(0) -> still level 0 (F(a-1) < u <= F(a))
+        (0.5 + 1e-9, 1),  # just above F(0) -> next level
+        (0.75 - 1e-9, 1),
+        (0.75 + 1e-9, 2),  # just above F(1)
+        (0.875 + 1e-9, 3),
+        (1.0 - 1e-12, 4),  # top level, no overflow past K - 1
+    ],
+)
+def test_inverse_cdf_convention(monkeypatch, u, expected):
+    """rho = 0.25 so sqrt(rho) = 0.5 exactly: the latent carries ndtri(u) / 0.5
+    and comes back as ndtri(u) with no rounding, while the idiosyncratic draw
+    is zeroed -- u reaches the inversion exactly as prescribed."""
+    from scipy.special import ndtri
+
+    rho = 0.25
+    proba = th.tensor([DYADIC], dtype=th.float64)  # cumsum .5/.75/.875/.9375/1
+    latent = np.array([ndtri(u) / math.sqrt(rho)])
+    seen = []
+
+    def fake_randn(n, dtype=None, device=None):
+        seen.append(n)
+        vals = latent if len(seen) == 1 else np.zeros(n)
+        return th.tensor(vals, dtype=th.float64)
+
+    monkeypatch.setattr(copula.th, "randn", fake_randn)
+    lvl = sample_levels_copula(proba, th.zeros(1, dtype=th.int64), rho)
+    assert seen == [1, 1], "expected exactly 2 randn calls of size N"
+    assert lvl.tolist() == [expected]
+    assert lvl.dtype == th.int64
+
+
+def test_shape_and_dtype_follow_cells():
+    """The copula branch must return what ``IntEncoder.decode`` returns at the
+    same call site: int64 of shape ``proba.shape[:-1]``."""
+    proba = th.rand(3, 4, N_LEVELS).softmax(-1)
+    cells = th.zeros(3, 4, dtype=th.int64)
+    th.manual_seed(0)
+    lvl = sample_levels_copula(proba, cells, 0.4)
+    assert lvl.shape == (3, 4) and lvl.dtype == th.int64
+    assert int(lvl.min()) >= 0 and int(lvl.max()) <= N_LEVELS - 1
+
+
+# --------------------------------------------------------------------------- #
+# (b) marginals preserved at every rho
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("rho", [0.0, 0.35, 0.9])
+def test_marginals_match_proba(rho):
+    """Per-row level frequencies must match the given proba within 4 binomial
+    SEs (SE = sqrt(p(1-p)/N)); levels with fewer than 20 expected counts are
+    skipped, the normal approximation not being usable there. rho changes the
+    dependence only -- never the marginal."""
+    proba = proba_block([3, 7, 10, 12, 15, 18, 20, 0])
+    th.manual_seed(11)
+    draws = sample_levels_copula(
+        repeat_rows(proba, N_DRAW), repeat_cells(GROUPS, N_DRAW), rho
+    ).numpy()
+    P = proba.double().numpy()
+    worst = 0.0
+    for agent in range(N_AGENTS):
+        freq = np.bincount(draws[:, agent], minlength=N_LEVELS) / N_DRAW
+        for lvl in range(N_LEVELS):
+            p = P[agent, lvl]
+            if p * N_DRAW < 20:
+                continue
+            se = math.sqrt(p * (1.0 - p) / N_DRAW)
+            worst = max(worst, abs(freq[lvl] - p) / se)
+    assert worst < 4.0, f"rho={rho}: worst deviation {worst:.2f} binomial SEs"
+
+
+def test_mean_contribution_unchanged():
+    """Blunter but load-bearing: the per-agent mean level is what the group
+    statistics are built from, and the copula must not move it."""
+    proba = proba_block([3, 7, 10, 12, 15, 18, 20, 0])
+    P = proba.double().numpy()
+    k = np.arange(N_LEVELS)
+    target = (P * k).sum(1)
+    sd = np.sqrt((P * k**2).sum(1) - target**2)
+    for rho in (0.0, 0.5):
+        th.manual_seed(13)
+        draws = sample_levels_copula(
+            repeat_rows(proba, N_DRAW), repeat_cells(GROUPS, N_DRAW), rho
+        ).numpy()
+        dev = np.abs(draws.mean(0) - target) / (sd / math.sqrt(N_DRAW))
+        assert dev.max() < 4.0, f"rho={rho}: worst mean shift {dev.max():.2f} SEs"
+
+
+# --------------------------------------------------------------------------- #
+# (c) within-cell correlation, cross-cell independence
+# --------------------------------------------------------------------------- #
+@pytest.fixture(scope="module")
+def same_row_draws():
+    """All eight agents share one proba row, so any level correlation can only
+    come from the shared latent, never from shared features."""
+    proba = proba_block([9] * N_AGENTS)
+    out = {}
+    for name, rho in (("rho05", 0.5), ("rho0", 0.0)):
+        th.manual_seed(12)
+        out[name] = sample_levels_copula(
+            repeat_rows(proba, N_DRAW), repeat_cells(GROUPS, N_DRAW), rho
+        ).numpy()
+    return out
+
+
+def test_within_cell_correlation_induced(same_row_draws):
+    """Discretising the latent costs dependence, so the level correlation lands
+    below rho itself; asserted as "many SEs above zero" (the SE of a zero
+    correlation is 1/sqrt(N))."""
+    within = pair_corr(same_row_draws["rho05"], WITHIN)
+    assert within > 6.0 / math.sqrt(N_DRAW), f"within-cell corr {within:.4f}"
+    assert within > 0.2, f"within-cell corr {within:.4f} implausibly weak at rho=0.5"
+
+
+def test_cross_cell_correlation_absent(same_row_draws):
+    cross = pair_corr(same_row_draws["rho05"], CROSS)
+    assert abs(cross) < 4.0 / math.sqrt(N_DRAW), f"cross-cell corr {cross:.4f}"
+
+
+def test_rho_zero_leaves_rows_independent(same_row_draws):
+    for pairs, label in ((WITHIN, "within"), (CROSS, "cross")):
+        corr = pair_corr(same_row_draws["rho0"], pairs)
+        assert abs(corr) < 4.0 / math.sqrt(N_DRAW), f"{label} corr {corr:.4f} at rho=0"
+
+
+def test_one_cell_shares_one_latent():
+    """Every row of a cell reads one latent: with identical proba rows and rho
+    at the independence-free end, the sampled levels coincide."""
+    proba = proba_block([9] * 4)
+    th.manual_seed(3)
+    lvl = sample_levels_copula(proba, th.zeros(4, dtype=th.int64), 0.999999)
+    assert len(set(lvl.tolist())) == 1
+
+
+# --------------------------------------------------------------------------- #
+# (d) determinism and composition-stable RNG consumption
+# --------------------------------------------------------------------------- #
+def test_determinism_under_seed():
+    proba = proba_block([3, 7, 10, 12, 15, 18, 20, 0])
+    cells = th.tensor(GROUPS)
+    th.manual_seed(42)
+    first = [sample_levels_copula(proba, cells, 0.35) for _ in range(20)]
+    th.manual_seed(42)
+    again = [sample_levels_copula(proba, cells, 0.35) for _ in range(20)]
+    for a, b in zip(first, again):
+        assert th.equal(a, b)
+    # ...and the sampler is genuinely drawing, not returning a fixed vector
+    assert not all(th.equal(first[0], x) for x in first[1:])
+
+
+@pytest.mark.parametrize("rho", [0.0, 0.35])
+def test_cell_composition_does_not_shift_the_stream(rho):
+    """Exactly 2N draws per call whatever the cell composition (rho = 0
+    included), so partitions differ only through the latent assignment, never
+    through a desynchronised RNG."""
+    proba = proba_block([3, 7, 10, 12, 15, 18, 20, 0])
+    partitions = [
+        GROUPS,
+        list(range(N_AGENTS)),  # all singletons
+        [0] * N_AGENTS,  # one cell
+        [5, 2, 5, 2, 5, 2, 5, 2],  # interleaved, unsorted ids
+    ]
+    tails = []
+    for cells in partitions:
+        th.manual_seed(7)
+        sample_levels_copula(proba, th.tensor(cells), rho)
+        tails.append(th.randn(1).item())
+    assert len(set(tails)) == 1, f"RNG consumption varies with composition: {tails}"
+    th.manual_seed(7)
+    th.randn(2 * N_AGENTS, dtype=th.float64)
+    assert th.randn(1).item() == tails[0], "expected exactly 2N float64 draws"
+
+
+# --------------------------------------------------------------------------- #
+# (e) the first-member latent rule
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "cells",
+    [
+        [0, 0, 1, 1, 0, 1, 0, 1],
+        [1, 1, 0, 0, 1, 0, 1, 0],  # same partition, first members swapped
+        [7, 3, 7, 3, 3, 7, 3, 7],  # unsorted ids: th.unique sorts, order must not
+        [4, 4, 4, 4, 4, 4, 4, 4],
+    ],
+)
+def test_first_member_latent_rule(cells):
+    """Each cell's latent is the `zs` slot of its FIRST member in flattened row
+    order -- pinned against a dict-based reimplementation, so relabelling or
+    reordering the ids cannot silently change which draw is shared."""
+    proba = proba_block([3, 7, 10, 12, 15, 18, 20, 0])
+    cells = th.tensor(cells)
+    th.manual_seed(5)
+    want = reference_levels(proba, cells, 0.35)
+    th.manual_seed(5)
+    got = sample_levels_copula(proba, cells, 0.35)
+    assert th.equal(want, got), f"{want.tolist()} != {got.tolist()}"
+
+
+def test_first_member_rule_matters():
+    """Guard against a vacuous pin: reading each cell's LAST member's slot
+    instead of its first gives different levels, so the rule above has teeth."""
+    proba = proba_block([3, 7, 10, 12, 15, 18, 20, 0])
+    cells = th.tensor([0, 0, 1, 1, 0, 1, 0, 1])
+    th.manual_seed(5)
+    got = sample_levels_copula(proba, cells, 0.9)
+    th.manual_seed(5)
+    last = reference_levels(proba, cells, 0.9, member="last")
+    assert not th.equal(got, last), "sampler is not using the first member"
+
+
+def test_relabelling_cells_leaves_the_draw_unchanged():
+    """Cell ids are labels, not an ordering: relabelling a partition moves no
+    row, so the first member of each cell -- and the result -- is unchanged."""
+    proba = proba_block([3, 7, 10, 12, 15, 18, 20, 0])
+    th.manual_seed(5)
+    a = sample_levels_copula(proba, th.tensor([0, 0, 1, 1, 0, 1, 0, 1]), 0.9)
+    th.manual_seed(5)
+    b = sample_levels_copula(proba, th.tensor([1, 1, 0, 0, 1, 0, 1, 0]), 0.9)
+    assert th.equal(a, b)
+
+
+def test_multi_dim_cells_flatten_row_major():
+    """(rows, rounds) input: the flattened order the GNN decode sees is row
+    then round, and the (row, round) result must equal the flat-call result."""
+    proba = proba_block([3, 7, 10, 12]).reshape(2, 2, N_LEVELS)
+    cells = th.tensor([[0, 1], [0, 1]])
+    th.manual_seed(17)
+    nested = sample_levels_copula(proba, cells, 0.4)
+    th.manual_seed(17)
+    flat = sample_levels_copula(
+        proba.reshape(-1, N_LEVELS), cells.reshape(-1), 0.4
+    )
+    assert th.equal(nested.reshape(-1), flat)
+
+
+# --------------------------------------------------------------------------- #
+# (f) parity with the punisher adapter (PR #146)
+# --------------------------------------------------------------------------- #
+def _fixed_proba_adapter(rows, rho):
+    """LinearAHAdapter over a stub estimator whose predict_proba returns `rows`
+    verbatim. Dyadic rows sum to exactly 1, so _class_probs' floor-and-
+    renormalise is the identity and both samplers invert the same CDF."""
+
+    class FixedProba:
+        classes_ = np.arange(len(rows[0]))
+
+        def predict_proba(self, Xs):
+            return np.asarray(rows, dtype=float).copy()
+
+    return LinearAHAdapter(
+        dict(
+            model="multinomial",
+            estimator=FixedProba(),
+            scaler=None,
+            features=list(FEATS),
+            target="punishment",
+            n_levels=len(rows[0]),
+            default_values=dict(DEFAULTS),
+            copula_rho=rho,
+        )
+    )
+
+
+@pytest.mark.parametrize("groups", [[0, 0, 1, 1], [7, 3, 7, 3], [2, 2, 2, 2]])
+@pytest.mark.parametrize("rho", [0.0, 0.35, 0.9])
+def test_parity_with_linear_adapter(groups, rho):
+    """Same probabilities, same cell ids, same seed -> the same levels as
+    ``LinearAHAdapter._sample_levels_copula``. This is what lets the two slots
+    be calibrated by one estimator."""
+    rows = [
+        DYADIC,
+        DYADIC[::-1],
+        [0.25, 0.25, 0.25, 0.125, 0.125],
+        [0.125, 0.125, 0.5, 0.125, 0.125],
+    ]
+    ad = _fixed_proba_adapter(rows, rho)
+    th.manual_seed(23)
+    want = ad._sample_levels_copula(np.zeros((4, len(FEATS))), len(rows[0]), groups)
+    th.manual_seed(23)
+    got = sample_levels_copula(
+        th.tensor(rows, dtype=th.float64), th.tensor(groups), rho
+    )
+    assert got.tolist() == want.tolist(), f"{got.tolist()} != {want.tolist()}"
+
+
+def test_parity_leaves_the_stream_where_the_adapter_does():
+    """Same 2N consumption as the adapter, so a mixed stack (linear punisher +
+    copula contributor) keeps one reproducible stream."""
+    rows = [DYADIC, DYADIC[::-1], DYADIC, DYADIC[::-1]]
+    ad = _fixed_proba_adapter(rows, 0.35)
+    th.manual_seed(29)
+    ad._sample_levels_copula(np.zeros((4, len(FEATS))), len(rows[0]), [0, 0, 1, 1])
+    after_adapter = th.randn(1).item()
+    th.manual_seed(29)
+    sample_levels_copula(
+        th.tensor(rows, dtype=th.float64), th.tensor([0, 0, 1, 1]), 0.35
+    )
+    assert th.randn(1).item() == after_adapter
+
+
+# --------------------------------------------------------------------------- #
+# (g) input guards
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("rho", [1.0, 1.5, -0.1, -1e-9])
+def test_rho_outside_unit_interval_raises(rho):
+    proba = proba_block([9, 9])
+    with pytest.raises(AssertionError, match=r"\[0, 1\)"):
+        sample_levels_copula(proba, th.zeros(2, dtype=th.int64), rho)
+
+
+@pytest.mark.parametrize(
+    "shape", [(3,), (2, 2), (4, 1), ()]  # too short, wrong rank, wrong length
+)
+def test_cells_shape_mismatch_raises(shape):
+    proba = proba_block([9, 9])  # (2, K) -> cells must be (2,)
+    with pytest.raises(AssertionError, match="does not match"):
+        sample_levels_copula(proba, th.zeros(shape, dtype=th.int64), 0.35)


### PR DESCRIPTION
Autoresearch experiment on the contribution slot. Full log: `notes/autoresearch_log/contribution-cg-copula.md`.

## Hypothesis

Group members co-move because they share a situation and share the model's error about it, but the sim draws every agent's contribution independently, pinning the group-mean spread near the independence floor (the PR #140 analysis; human ratio 0.85 vs free-running sim ~0.59). A within-round exchangeable Gaussian copula at the GNN contributor's free-running draw — one shared latent per (group, round) through each agent's own predicted CDF, rho by pairwise-likelihood MLE (the PR #146 mechanism) — should restore group co-movement while preserving every individual marginal exactly, avoiding the RCA/RCB price that made #144/#147 fail. Target: **CG 9.808514** (re-baselined to the severity-copula reference stack), band > 5; success required CG < 5.

## Results

| date | change (one line) | stage | target scores | rows <= 1 | mean | verdict |
|---|---|---|---|---|---|---|
| 2026-08-12 | (baseline) reference stack, severity-copula punisher (#146 Stage-1 run) | 1 | CG 9.808514 | 10/21 | 1.687998 | baseline |
| 2026-08-12 | arm A: M0 + copula, rho=0.06958238086256316 (calibration only) | — | preflight spread ratio 0.7837 -> 0.7928 (human 0.8473) | no sim | no sim | stopped at step-11 gate |
| 2026-08-12 | arm B: M4 + copula, rho=0.06339366830297524 (calibration only) | — | preflight spread ratio 0.8016 -> 0.8100 (human 0.8473) | no sim | no sim | stopped at step-11 gate |

Both estimators passed every honesty gate (round-trip recovery max |bias| < 0.01 against a 0.03 tolerance; bootstrap CIs clearly above 0: M0 [0.046, 0.085], M4 [0.044, 0.078]). But the calibrated rho closes only **~14% of the teacher-forced spread gap** — almost exactly the ~1/6 sampler share the PR #140 decomposition predicted — so a CG band upgrade (9.81 → < 5) was implausible and the maintainer ruled **stop after calibration**: no Stage-1 sim, no Stage 2. Per the framework this is a `[FAIL]`, never merged, kept so the next agent does not retry it.

**The finding that matters:** teacher-forced, M0's *independent* group-spread ratio is already **0.784** vs the free-running sim's ~0.59. The CG deficit is overwhelmingly **free-running state-tracking loss** — the model tracks its group fine when fed real histories and drifts only under its own dynamics. Within-round sampling was never the binding constraint. Secondary: residual dependence grows over the game (rho by round thirds 0.035 / 0.074 / 0.119 — late-game norm lock-in), and M4's peer features demonstrably absorb dependence into conditioning (independent ratio 0.802 vs 0.784, residual rho 0.063 vs 0.070).

Directions this points to, in order: (i) free-running state tracking (scheduled sampling / free-running-aware training); (ii) an episode-persistent shared latent (PR #140 Option 1 — it compounds, and the human early-late segregation correlation 0.38 vs sim 0.03 is direct evidence); (iii) a round-growing rho.

## Collateral

None — no simulation was run. Durable code products stay on this branch, all tested (45 local + 27 remote tests, full suites green): `src/aimanager/generic/copula.py` (pure-torch marginal-preserving sampler), the `GraphNetwork.copula_rho` wiring (legacy artifacts bit-identical at 0.0), `scripts/artificial_humans/contribution_copula_rho.py` + SLURM wrapper, and both calibrated artifacts with full provenance sidecars — reusable as-is by an episode-persistent-latent follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)